### PR TITLE
SwSh Item RNG Retail - fix link within page

### DIFF
--- a/retail/swsh/item/index.html
+++ b/retail/swsh/item/index.html
@@ -430,7 +430,7 @@ permalink: /retail/swsh/item/
 <p><span class="fw-bold">That's all there is to RNG abusing the lottery minigame on retail hardware!</span></p>
 
 <hr /><div class="title" style="background-color: #0c0038;">
-  <h1 class="text-light text-center pt-3 pb-3" id="watt-trader-rng-abuse">Watt Trader RNG abuse</h1>
+  <h1 class="text-light text-center pt-3 pb-3" id="watt-trader-rng-abuse-retail">Watt Trader RNG abuse</h1>
 </div><hr />
 
 <p>The goal is to interact with the Watt Trader in Snowslide Slope on the calculated target frame given to us by the <code class="fw-bold">Watt Trader</code> window of the generator, we will be using the advancement methods listed in the table above to hit the target frame, most notably, menu close, animations & date skipping.</p>


### PR DESCRIPTION
Currently, when you click `Watt Trader`, nothing happens. Because it sends you to `watt-trader-rng-abuse-retail`. But currently the header is `watt-trader-rng-abuse`, so I updated this header.