### PR TITLE
Proofread all SWSH Item Guides & Add Audino Calibration

### DIFF
--- a/cfw/swsh/item/cram-o-matic/index.html
+++ b/cfw/swsh/item/cram-o-matic/index.html
@@ -166,17 +166,19 @@ permalink: /cfw/swsh/item/cram-o-matic/
             <p></p>
             <li>Open the <code class="fw-bold">X Menu</code> to pause the game.</li>
             <p></p>
-            <li>Click <code class="fw-bold">Update Seeds</code> on the main window of owoow to reflect your current seed into the active subwindow. Now search for your target again.</li>
+            <li>Click <code class="fw-bold">Update Seeds</code> on the main window of owoow to send your current seed into the active subwindow.</li>
+            <p></p>
+            <li>Ensure that the <code class="fw-bold">Consider Menu Close?</code> checkbox is checked in the Cram-o-matic subwindow, and confirm that your NPC count has been calibrated and entered correctly. Search for your target again.</li>
+            <p></p>
+            <ul>
+                <li>Do not use the <code class="fw-bold">Holding Direction?</code> checkbox on owoow. This increases the difficulty of hitting your target frame as we are already standing next to the Cram-o-matic.</li>
+            </ul>
             <p></p>
             <li>From this point, use <a class="clickable-image" data-image="https://raw.githubusercontent.com/Billo-PS/billo-guides-images/refs/heads/main/cfw/swsh/overworld/advancing-rng-state/animations.gif">attack animations</a> to reach the exact target frame.</li>
             <p></p>
             <li>Close the Pok&eacute;mon window so you are on the main <code class="fw-bold">X Menu</code>.</li>
             <p></p>
-            <li>Unpause the game by pressing B.</li>
-            <p></p>
-            <ul>
-                <li>Do not hold a direction when unpausing the game, or have the <code class="fw-bold">Holding Direction?</code> checkbox active on owoow. This increases the difficulty of hitting your target frame as we are already standing next to the Cram-o-matic.</li>
-            </ul>
+            <li>Unpause the game by pressing B. Do not touch the joystick when unpausing as we are already positioned next to the Cram-o-matic.</li>
             <p></p>
             <li>Quickly interact with the Cram-o-matic to lock your item result in place. Now you can take your time feeding the correct combination of items in the correct order to produce the expected reward.</li>
         </ol>

--- a/cfw/swsh/item/digging-pa/index.html
+++ b/cfw/swsh/item/digging-pa/index.html
@@ -67,6 +67,8 @@ permalink: /cfw/swsh/item/digging-pa/
             <p></p>
             <li>Verify the weather condition by opening the map. If the current weather is Rain/Thunderstorm, change the date so the weather is anything calm.</li>
             <p></p>
+            <li>Move far enough away so that the NPC deactivates. You can tell if you are positioned correctly if he turns away and resumes his idle animation.</li>
+            <p></p>
             <li>Now you will need to position yourself optimally. This is done with a movement technique that disrupts the NPCs "activation":</li>
             <p></p>
             <ul>
@@ -79,9 +81,9 @@ permalink: /cfw/swsh/item/digging-pa/
                 <li>You should retry until the NPC is in the correct state. If you failed, move away until he becomes inactive, then try again. It may take a few attempts to get the NPC into the correct state, but this provides the most stable experience possible for this type of RNG manipulation.</li>
             </ul>
             <p></p>
-            <li>Calibrate your menu NPC count as usual. The NPC count when standing next Digging Pa is will change by the day. Enter your calibrated NPC count in the Digging Pa subwindow on owoow.</li>
+            <li>Once the NPC is in the correct state, calibrate your menu NPC count as usual. The NPC count when standing next Digging Pa will change by the day. Enter your calibrated NPC count in the Digging Pa subwindow on owoow.</li>
             <p></p>
-            <li>Save the game. This will preserve the current NPC state upon resetting as long as you reopen the game on the same date or an earlier date.</li>
+            <li>Save the game. This will preserve the current deactivated NPC state through resets. The menu NPC count will also remain long as you reopen the game on the same date or an earlier date.</li>
         </ol>
 
         <p>You will want to use the positioning pictured in Figure 2 when attempting to interact with Digging Pa to avoid spawning unwanted Pok&eacute;mon inside the Warm-Up Tunnel.</p>
@@ -122,17 +124,20 @@ permalink: /cfw/swsh/item/digging-pa/
             <p></p>
             <li>Open the <code class="fw-bold">X Menu</code> to pause the game.</li>
             <p></p>
-            <li>Click <code class="fw-bold">Update Seeds</code> on the main window of owoow to reflect your current seed into the active subwindow. Now search for your target again.</li>
+            <li>Click <code class="fw-bold">Update Seeds</code> on the main window of owoow to send your current seed into the active subwindow.</li>
+            </ul>
+            <p></p>
+            <li>Ensure that the <code class="fw-bold">Consider Menu Close?</code> checkbox is checked in the Digging Pa subwindow, and confirm that your NPC count has been calibrated and entered correctly. Search for your target again.</li>
+            <p></p>
+            <ul>
+                <li>Do not use the <code class="fw-bold">Holding Direction?</code> checkbox on owoow. Attempting to use direction hold will cause the NPC to activate and you will miss your target frame.</li>
+            </ul>
             <p></p>
             <li>From this point, use <a class="clickable-image" data-image="https://raw.githubusercontent.com/Billo-PS/billo-guides-images/refs/heads/main/cfw/swsh/overworld/advancing-rng-state/animations.gif">attack animations</a> to reach the exact target frame.</li>
             <p></p>
             <li>Close the Pok&eacute;mon window so you are on the main <code class="fw-bold">X Menu</code>.</li>
             <p></p>
-            <li>Unpause the game by pressing B.</li>
-            <p></p>
-            <ul>
-                <li>Do not hold a direction when unpausing the game, or have the <code class="fw-bold">Holding Direction?</code> checkbox active on owoow. This increases the difficulty of hitting your target frame as we are already standing next to the NPC we need to interact with.</li>
-            </ul>
+            <li>Unpause the game by pressing B. Do not touch the joystick when unpausing or you can lose the deactivated NPC state.</li>
             <p></p>
             <li>Quickly interact with Digging Pa to lock in your hoard of Watts. Agree to trade him Armorite Ore and click A until he is exhausted.</li>
         </ol>

--- a/cfw/swsh/item/loto-id/index.html
+++ b/cfw/swsh/item/loto-id/index.html
@@ -40,7 +40,7 @@ permalink: /cfw/swsh/item/loto-id/
             <p></p>
             <li>If you have already attempted Loto-ID today, reset the daily events by either waiting until midnight or performing a date skip.</li>
             <p></p>
-            <li>Save the game.</li>
+            <li>Save the game. Calibrate your NPC count if you are not using Turffield Pok&eacute;mon Center.</li>
         </ol>
 
         <p>The NPC count for each Pok&eacute;mon Center is different. We recommend using the Turffield Pok&eacute;mon Center to RNG manipulate Loto-ID because NPCs in this Pok&eacute;mon Center are conveniently placed and this location will always have an NPC count of 7.</p>
@@ -61,13 +61,13 @@ permalink: /cfw/swsh/item/loto-id/
             <p></p>
             <li>At the top of the main owoow window, click <code class="fw-bold">Loto-ID</code> to open the Loto-ID generator in a subwindow.</li>
             <p></p>
-            <li>Enter the number of advances you want to search in the <code class="fw-bold">+</code> field. You will usually find any desired result in 100,000 advances or fewer.</li>
+            <li>Enter the number of advances you want to search in the <code class="fw-bold">+</code> field. You will usually find any desired result in under 100,000 advances.</li>
             <p></p>
             <li>Select your <code class="fw-bold">Target</code> reward from the drop-down menu. You can target Master Ball, Rare Candy, PP Max, PP Up, or Moomoo Milk.</li>
             <p></p>
             <li>Click the <code class="fw-bold">ID List</code> button to open the ID List. Add all the unique Trainer ID numbers of your deposited Pok&eacute;mon by entering each number in the <code class="fw-bold">ID:</code> field, then clicking <code class="fw-bold">Add</code>. The more IDs in this list, the greater the chance of finding an early result.</li>
             <p></p>
-            <li>Tick the <code class="fw-bold">Consider Menu Close?</code> checkbox, then enter the NPC count. if you are in Turffield, enter 7. If you are elsewhere, calibrate the NPCs yourself. You can now begin searching for targets.</li>
+            <li>Tick the <code class="fw-bold">Consider Menu Close?</code> checkbox, then enter the NPC count. If you are in Turffield, enter 7. If you are elsewhere, use the menu NPCs you calculated previously. You can now begin searching for targets.</li>
         </ol>
 
         <p>If you do not find any results, make sure you have IDs entered first. If you still do not find any results, you will need to increase your search range, change your search filters to be less restrictive, or reset the game for a better seed.</p>
@@ -100,17 +100,19 @@ permalink: /cfw/swsh/item/loto-id/
             <p></p>
             <li>Open the <code class="fw-bold">X Menu</code> to pause the game.</li>
             <p></p>
-            <li>Click <code class="fw-bold">Update Seeds</code> on the main window of owoow to reflect your current seed into the active subwindow. Now search for your target again.</li>
+            <li>Click <code class="fw-bold">Update Seeds</code> on the main window of owoow to send your current seed into the active subwindow.</li>
+            <p></p>
+            <li>Ensure that the <code class="fw-bold">Consider Menu Close?</code> checkbox is checked in the Loto-ID subwindow, and confirm that your NPC count has been calibrated and entered correctly. Search for your target again.</li>
+            <p></p>
+            <ul>
+                <li>Do not use the <code class="fw-bold">Holding Direction?</code> checkbox on owoow. This increases the difficulty of hitting your target frame as we are already standing next to the Rotom PC.</li>
+            </ul>
             <p></p>
             <li>From this point, use <a class="clickable-image" data-image="https://raw.githubusercontent.com/Billo-PS/billo-guides-images/refs/heads/main/cfw/swsh/overworld/advancing-rng-state/animations.gif">attack animations</a> to reach the exact target frame.</li>
             <p></p>
             <li>Close the Pok&eacute;mon window so you are on the main <code class="fw-bold">X Menu</code>.</li>
             <p></p>
-            <li>Unpause the game by pressing B.</li>
-            <p></p>
-            <ul>
-                <li>Do not hold a direction when unpausing the game, or have the <code class="fw-bold">Holding Direction?</code> checkbox active on owoow. This increases the difficulty of hitting your target frame as we are already standing next to the Rotom PC.</li>
-            </ul>
+            <li>Unpause the game by pressing B. Do not touch the joystick when unpausing as we are already positioned next to to the Rotom PC.</li>
             <p></p>
             <li>Quickly interact with the Rotom PC to lock your item result in place. Now select <code class="fw-bold">Try Loto-ID</code> to get your reward.</li>
         </ol>

--- a/cfw/swsh/item/wailord-respawn/index.html
+++ b/cfw/swsh/item/wailord-respawn/index.html
@@ -82,7 +82,9 @@ permalink: /cfw/swsh/item/wailord-respawn/
             <p></p>
             <li>Open the <code class="fw-bold">X Menu</code> to pause the game.</li>
             <p></p>
-            <li>Click <code class="fw-bold">Update Seeds</code> on the main window of owoow to reflect your current seed into the active subwindow. Now search for your target again.</li>
+            <li>Click <code class="fw-bold">Update Seeds</code> on the main window of owoow to reflect your current seed into the active subwindow.</li>
+            <p></p>
+            <li>Ensure that the <code class="fw-bold">Consider Menu Close?</code> and <code class="fw-bold">Holding Direction?</code> checkboxes are checked in the Wailord Respawn subwindow, and confirm that your NPC count has been entered correctly. Search for your target again.</li>
             <p></p>
             <li>From this point, use <a class="clickable-image" data-image="https://raw.githubusercontent.com/Billo-PS/billo-guides-images/refs/heads/main/cfw/swsh/overworld/advancing-rng-state/animations.gif">attack animations</a> to reach the exact target frame.</li>
             <p></p>

--- a/cfw/swsh/item/watt-trader/index.html
+++ b/cfw/swsh/item/watt-trader/index.html
@@ -45,10 +45,6 @@ permalink: /cfw/swsh/item/watt-trader/
             <p></p>
             <li>Set the weather in the <code class="fw-bold">Encounter Settings</code> section of the main owoow window to the current weather condition in Snowslide Slope.</li>
             <p></p>
-            <ul>
-                <li>Avoid using Rain/Thunderstorm. These weather conditions are not supported as they are unnecessarily more difficult for no advantage.</li>
-            </ul>
-            <p></p>
             <li>At the top of the main owoow window, click <code class="fw-bold">Watt Trader</code> to open the Watt Trader generator in a subwindow.</li>
             <p></p>
             <li>Enter your search filters, then enter the number of advances you want to search in the <code class="fw-bold">+</code> field. Usually you will find a result that produces a Dream/Beast Ball in 10,000 advances or fewer.</li>
@@ -76,7 +72,9 @@ permalink: /cfw/swsh/item/watt-trader/
         <ol>
             <li>Head to the location in Snowslide Slope pictured above. If this is your first time, interact with the Watt Trader NPC at least once to unlock the fly point and complete his introduction.</li>
             <p></p>
-            <li>Verify the weather condition by opening the map. If the current weather is Rain/Thunderstorm, change the date so the weather is anything calm.</li>
+            <li>Verify the weather condition by checking the map. Ensure that this matches the setting in owoow.</li>
+            <p></p>
+            <li>Move far enough away so that the NPC deactivates. You can tell if you are positioned correctly if he turns away and resumes his idle animation.</li>
             <p></p>
             <li>Now you will need to position yourself optimally. This is done with a movement technique that disrupts the NPCs "activation":</li>
             <p></p>
@@ -94,7 +92,7 @@ permalink: /cfw/swsh/item/watt-trader/
             <p></p>
             <li>Perform a date skip to refresh the daily highlight item. This can be done using owoow's date skipping features, the Raid exploit, or the PvP date skipping exploit.</li>
             <p></p>
-            <li>Save the game. This will preserve the current NPC state upon resetting as long as you reopen the game on the same date or an earlier date. Do not speak to the NPC again until you reach your target frame.</li>
+            <li>Save the game. This will preserve the current deactivated NPC state through resets. The menu NPC count will also remain long as you reopen the game on the same date or an earlier date.</li>
         </ol>
     </div>
 </div>
@@ -134,17 +132,20 @@ permalink: /cfw/swsh/item/watt-trader/
             <p></p>
             <li>Open the <code class="fw-bold">X Menu</code> to pause the game.</li>
             <p></p>
-            <li>Click <code class="fw-bold">Update Seeds</code> on the main window of owoow to reflect your current seed into the active subwindow. Now search for your target again.</li>
+            <li>Click <code class="fw-bold">Update Seeds</code> on the main window of owoow to send your current seed into the active subwindow.</li>
+            </ul>
+            <p></p>
+            <li>Ensure that the <code class="fw-bold">Consider Menu Close?</code> checkbox is checked in the Digging Pa subwindow, and confirm that your NPC count has been calibrated and entered correctly. Search for your target again.</li>
+            <p></p>
+            <ul>
+                <li>Do not use the <code class="fw-bold">Holding Direction?</code> checkbox on owoow. Attempting to use direction hold will cause the NPC to activate and you will miss your target frame.</li>
+            </ul>
             <p></p>
             <li>From this point, use <a class="clickable-image" data-image="https://raw.githubusercontent.com/Billo-PS/billo-guides-images/refs/heads/main/cfw/swsh/overworld/advancing-rng-state/animations.gif">attack animations</a> to reach the exact target frame.</li>
             <p></p>
             <li>Close the Pok&eacute;mon window so you are on the main <code class="fw-bold">X Menu</code>.</li>
             <p></p>
-            <li>Unpause the game by pressing B.</li>
-            <p></p>
-            <ul>
-                <li>Do not hold a direction when unpausing the game, or have the <code class="fw-bold">Holding Direction?</code> checkbox active on owoow. This increases the difficulty of hitting your target frame as we are already standing next to the NPC we need to interact with.</li>
-            </ul>
+            <li>Unpause the game by pressing B. Do not touch the joystick when unpausing or you can lose the deactivated NPC state.</li>
             <p></p>
             <li>Quickly interact with the Watt Trader NPC to lock in your desired item. To access your desired highlight item follow the steps directly below.</li>
         </ol>

--- a/cfw/swsh/overworld/roaming/dry.html
+++ b/cfw/swsh/overworld/roaming/dry.html
@@ -19,14 +19,38 @@
         </thead>
         <tbody>
             <tr>
-                <td class="text-center">46</td>
+                <td class="text-center">43-47 (see below)</td>
                 <td class="text-center">0</td>
                 <td class="text-center">0</td>
             </tr>
         </tbody>
     </table>
 
-    <p><span class="fw-bold">Note -</span> As mentioned above, you must Virizion caught or must not have progressed the footprint story quest enough to spawn Virizion in the otherworld. Having Virizion spawned will produce results not found inside the table.</p>
+    <div class="card border-dark">
+        <div class="anchored card-header text-light" style="background-color: #0c0038;" id="articuno-area-load-calibration">
+            <span class="fw-bold">Articuno Area Load Calibration</span>
+        </div>
+        <div class="card-body card-bg">
+            <p>An additional calibration for the <code class="fw-bold">Area Load</code> value is needed for Galarian Articuno. This value represents the total number of strong spawns that are loaded in the area and distantly (e.g. birds and IoA Wailord). Normally, this would be constant after a date skip, but the strong spawn Audino in the area only respawn at a 10% rate each new day when you first load the map. If any are missing when you are performing the RNG manipulation, this will cause your predictions to be inaccurate.</p>
+
+            <p>For this calibration, you will need to go to all 3 locations for the Audino and take note of which ones are spawning. Note that Audino has flee behavior, so if you scare one away, do not count it.</p>
+
+            <p><a href="https://www.youtube.com/watch?v=skRsVjEujEI">Video of Giant's Bed Audino Locations</a></p>
+
+            <p>The final <code class="fw-bold">Area Load</code> value should be calculated like so:
+            <ol>
+                <li>Start with 43.</li>
+                <p></p>
+                <li>Add the number of Audino that are loaded, which will be +1, +2, or +3.</li>
+                <p></p>
+                <li>Add 1 if Virizion is spawning.</li>
+            </ol></p>
+
+            <p>You should get a number from 43-47. Put the final value in the <code class="fw-bold">Area Load</code> box.</p>
+
+            <p>If you have any missing Audino and date skip, you will need to count them again before performing your RNG manipulation attempt.</p>
+        </div>
+    </div>
 </div>
 
 <div class="bird bird-zapdos d-none">

--- a/cfw/swsh/overworld/roaming/index.html
+++ b/cfw/swsh/overworld/roaming/index.html
@@ -49,7 +49,6 @@ permalink: /cfw/swsh/overworld/roaming/
             <p></p>
             <li>Adjust your search range using the <code class="fw-bold">+</code> field in <code class="fw-bold">Encounter Settings</code>, then configure additional search filters such as Marks, IVs, or Height.</li>
         </ol>
-
     </div>
 </div>
 <br />
@@ -100,15 +99,10 @@ permalink: /cfw/swsh/overworld/roaming/
                 <p></p>
                 <li>For Moltres, speak to the NPC inside the <a class="clickable-image" data-image="https://raw.githubusercontent.com/Billo-PS/billo-guides-images/refs/heads/main/cfw/swsh/overworld/roaming/dojo-npc.png">Dojo</a>.</li>
             </ul>
-
         </ol>
     </div>
 </div>
 <br>
-
-<div class="alert alert-danger" style="border: 1px solid #b60606; border-radius: 8px; padding: 15px; background-color: #f8d7da; color: #721c24;">
-    <span class="fw-bold">Important -</span> For Articuno, you must not be at a point in Sonia's footprint sidequest where Virizion spawns in the overworld. Either wait to talk to Sonia to activate Virizion or capture it to clear it from the field. When Virizion is actively spawning in the overworld, this causes additional RNG calls that are not accounted for by owoow. (Virizion can be RNG manipulated using the <a href="https://billo-guides.github.io/cfw/swsh/overworld/static/">Overworld Static RNG Manipulation</a> guide!)
-</div>
 
 <p><span class="fw-bold">Figure 3 -</span> Fondly Memory Demonstration</p>
 <img src="https://raw.githubusercontent.com/Billo-PS/billo-guides-images/refs/heads/main/cfw/swsh/overworld/roaming/fondly-memory.png" alt="owrng-roaming-3" class="img-fluid clickable-image" data-image="https://raw.githubusercontent.com/Billo-PS/billo-guides-images/refs/heads/main/cfw/swsh/overworld/roaming/fondly-memory.png"><p></p>
@@ -206,7 +200,6 @@ permalink: /cfw/swsh/overworld/roaming/
         <p>The calibration values (<code class="fw-bold">Consider Menu Close?</code> / <code class="fw-bold">Menu Close NPCs</code> <code class="fw-bold">Area Load</code> / <code class="fw-bold">Fly NPCs</code> / <code class="fw-bold">Rain Ticks</code>) will account for the advances consumed when exiting from the party list -> main pause menu -> opening map -> flying into the area that contains your bird.</p>
 
         <p><span class="fw-bold">After correctly setting your calibration values, you can begin searching for targets.</span></p>
-
     </div>
 </div>
 <br>

--- a/cfw/swsh/overworld/roaming/wet.html
+++ b/cfw/swsh/overworld/roaming/wet.html
@@ -24,7 +24,7 @@
         </thead>
         <tbody>
             <tr>
-                <td class="text-center">46</td>
+                <td class="text-center">43-47 (see below)</td>
                 <td class="text-center">7/8</td>
                 <td class="text-center">14/16</td>
                 <td class="text-center">3</td>
@@ -34,7 +34,31 @@
         </tbody>
     </table>
 
-    <p><span class="fw-bold">Note -</span> As mentioned above, you must Virizion caught or must not have progressed the footprint story quest enough to spawn Virizion in the otherworld. Having Virizion spawned will produce results not found inside the table.</p>
+    <div class="card border-dark">
+        <div class="anchored card-header text-light" style="background-color: #0c0038;" id="articuno-area-load-calibration">
+            <span class="fw-bold">Articuno Area Load Calibration</span>
+        </div>
+        <div class="card-body card-bg">
+            <p>An additional calibration for the <code class="fw-bold">Area Load</code> value is needed for Galarian Articuno. This value represents the total number of strong spawns that are loaded in the area and distantly (e.g. birds and IoA Wailord). Normally, this would be constant after a date skip, but the strong spawn Audino in the area only respawn at a 10% rate each new day when you first load the map. If any are missing when you are performing the RNG manipulation, this will cause your predictions to be inaccurate.</p>
+
+            <p>For this calibration, you will need to go to all 3 locations for the Audino and take note of which ones are spawning. Note that Audino has flee behavior, so if you scare one away, do not count it.</p>
+
+            <p><a href="https://www.youtube.com/watch?v=skRsVjEujEI">Video of Giant's Bed Audino Locations</a></p>
+
+            <p>The final <code class="fw-bold">Area Load</code> value should be calculated like so:
+            <ol>
+                <li>Start with 43.</li>
+                <p></p>
+                <li>Add the number of Audino that are loaded, which will be +1, +2, or +3.</li>
+                <p></p>
+                <li>Add 1 if Virizion is spawning.</li>
+            </ol></p>
+
+            <p>You should get a number from 43-47. Put the final value in the <code class="fw-bold">Area Load</code> box.</p>
+
+            <p>If you have any missing Audino and date skip, you will need to count them again before performing your RNG manipulation attempt.</p>
+        </div>
+    </div>
 </div>
 
 <div class="bird bird-zapdos d-none">

--- a/retail/swsh/item/cram-o-matic/index.html
+++ b/retail/swsh/item/cram-o-matic/index.html
@@ -162,25 +162,25 @@ permalink: /retail/swsh/item/cram-o-matic/
                 <p></p>
             <li>Stop advancing once you are ~300-500 advances before your target. Give yourself more leeway if you have left your position or do not have a rough idea of how many advances have occured. If you have moved, reposition yourself in front of the Cram-o-matic so you can immediately interact with it.</li>
             <p></p>
-            <li>
-                Open the <code class="fw-bold">X Menu</code> to pause the game then re-identify your current seed. Click <code class="fw-bold">Update Seeds</code> on the main window of owoow after re-identification to reflect your current seed into the active subwindow.
-                <p></p>
-                <ul>
-                    <li>If you are not yet within a few hundred advances of your target, use either of the "closer target" advancement methods listed in step 1 to advance the RNG state until you have reached the correct point. Be careful as you do not want to overshoot your target frame.</li>
-                </ul>
-                <p></p>
-            <li>
-                Ensure that the <code class="fw-bold">Consider Menu Close?</code> checkbox is checked in the Cram-o-matic subwindow, and confirm that your NPC count has been calibrated and entered correctly. Search for your target again.
-                <p></p>
-                <ul>
-                    <li>Do not use the <code class="fw-bold">Holding Direction?</code> checkbox on owoow. This increases the difficulty of hitting your target frame as we are already standing next to the Cram-o-matic.</li>
-                </ul>
-                <p></p>
+            <li>Open the <code class="fw-bold">X Menu</code> to pause the game.</li>
+            <p></p>
+            <li>Re-identify your current seed. Click <code class="fw-bold">Update Seeds</code> on the main window of owoow after re-identification, which will send your current seed to the active subwindow.</li>
+            <p></p>
+            <ul>
+                <li>If you are not within a few hundred advances of your target, use either of the "closer target" advancement methods listed in step 1 to advance the RNG state until you have reached the correct point. Be careful not to overshoot your target frame.</li>
+            </ul>
+            <p></p>
+            <li>Ensure that the <code class="fw-bold">Consider Menu Close?</code> checkbox is checked in the Cram-o-matic subwindow, and confirm that your NPC count has been calibrated and entered correctly. Search for your target again.</li>
+            <p></p>
+            <ul>
+                <li>Do not use the <code class="fw-bold">Holding Direction?</code> checkbox on owoow. This increases the difficulty of hitting your target frame as we are already standing next to the Cram-o-matic.</li>
+            </ul>
+            <p></p>
             <li>From this point, use <a class="clickable-image" data-image="https://raw.githubusercontent.com/Billo-PS/billo-guides-images/refs/heads/main/cfw/swsh/overworld/advancing-rng-state/animations.gif">attack animations</a> to reach the exact target frame. You can re-identify your current seed at any point if you wish.</li>
             <p></p>
             <li>Close the Pok&eacute;mon window so you are on the main <code class="fw-bold">X Menu</code>.</li>
             <p></p>
-            <li>Unpause the game by pressing B. Do not move the control stick when unpausing as we are already positioned next to the Cram-o-matic.</li>
+            <li>Unpause the game by pressing B. Do not touch the joystick when unpausing as we are already positioned next to the Cram-o-matic.</li>
             <p></p>
             <li>Quickly interact with the Cram-o-matic to lock your item result in place. Now you can take your time feeding the correct combination of items in the correct order to produce the expected reward.</li>
         </ol>

--- a/retail/swsh/item/digging-pa/index.html
+++ b/retail/swsh/item/digging-pa/index.html
@@ -65,7 +65,7 @@ permalink: /retail/swsh/item/digging-pa/
             <p></p>
             <li>Verify the weather condition by opening the map. If the current weather is Rain/Thunderstorm, change the date so the weather is anything calm.</li>
             <p></p>
-            <li>Move far enough away so that the NPC deactivates, you can tell if you are positioned correctly because they will turn and go back into their idle animation.</li>
+            <li>Move far enough away so that the NPC deactivates. You can tell if you are positioned correctly if he turns away and resumes his idle animation.</li>
             <p></p>
             <li>Identify your current seed at this stage. Now you will need to position yourself optimally. This is done with a movement technique that disrupts the NPCs "activation":</li>
             <p></p>
@@ -76,14 +76,14 @@ permalink: /retail/swsh/item/digging-pa/
                 <p></p>
                 <li>If you did this <a class="clickable-image" data-image="https://raw.githubusercontent.com/Billo-PS/billo-guides-images/refs/heads/main/cfw/swsh/item/watt-trader/incorrect-setup.gif">incorrectly</a>, the NPC will activate after backing out of the dialogue, causing the usual, extremely fast NPC activation advances we normally use for advancing the RNG state.</li>
                 <p></p>
-                <li>If you are unsure of your NPC state you can wait about 10 seconds and re-identify your seed. If you are noticing that ~1000 advances have occurred then you are NOT positioned correctly. Move away from the NPC and try again.</li>
+                <li>If you are unsure of your NPC state, you can wait about 10 seconds and re-identify your seed. If over 1000 advances have occurred, then you are NOT positioned correctly. Move away from the NPC and try again.</li>
                 <p></p>
                 <li>It may take a few attempts to get the NPC into the correct state, but this provides the most stable experience possible for this type of RNG manipulation.</li>
             </ul>
             <p></p>
-            <li>Once the NPC is in the correct state, calibrate your menu NPC count as usual. The NPC count when standing next Digging Pa is will change by the day. Enter your calibrated NPC count in the Digging Pa subwindow on owoow.</li>
+            <li>Once the NPC is in the correct state, calibrate your menu NPC count as usual. The NPC count when standing next Digging Pa will change by the day. Enter your calibrated NPC count in the Digging Pa subwindow on owoow.</li>
             <p></p>
-            <li>Save the game. This will preserve the current NPC state upon resetting as long as you reopen the game on the same date or an earlier date.</li>
+            <li>Save the game. This will preserve the current deactivated NPC state through resets. The menu NPC count will also remain long as you reopen the game on the same date or an earlier date.</li>
         </ol>
 
         <p>You will want to use the positioning pictured in Figure 2 when attempting to interact with Digging Pa to avoid spawning unwanted Pok&eacute;mon inside the Warm-Up Tunnel.</p>
@@ -121,27 +121,27 @@ permalink: /retail/swsh/item/digging-pa/
                     <li>For closer targets, consider using <a class="clickable-image" data-image="https://raw.githubusercontent.com/Billo-PS/billo-guides-images/refs/heads/main/cfw/swsh/overworld/advancing-rng-state/bike-mount.gif">bike hopping</a> or <a class="clickable-image" data-image="https://raw.githubusercontent.com/Billo-PS/billo-guides-images/refs/heads/main/cfw/swsh/overworld/advancing-rng-state/menu-close.gif">menu close</a>.</li>
                 </ul>
                 <p></p>
-            <li>Stop advancing once you are ~300-500 advances before your target. Give yourself if you do not have a rough idea of how many advances have occured.</li>
+            <li>Stop advancing once you are ~300-500 advances before your target. Give yourself extra leeway if you do not have a rough idea of how many advances have occurred.</li>
             <p></p>
-            <li>
-                Open the <code class="fw-bold">X Menu</code> to pause the game then re-identify your current seed. Click <code class="fw-bold">Update Seeds</code> on the main window of owoow after re-identification to reflect your current seed into the active subwindow.
-                <p></p>
-                <ul>
-                    <li>If you are not yet within a few hundred advances of your target, use the advancement methods listed in step 1 to advance the RNG state until you have reached the correct point. Be careful as you do not want to overshoot your target frame.</li>
-                </ul>
-                <p></p>
-            <li>
-                Ensure that the <code class="fw-bold">Consider Menu Close?</code> checkbox is checked in the Digging Pa subwindow, and confirm that your NPC count has been calibrated and entered correctly. Search for your target again.
-                <p></p>
-                <ul>
-                    <li>Do not use the <code class="fw-bold">Holding Direction?</code> checkbox on owoow. Attempting to use direction hold will cause the NPC to activate and you will miss your target frame.</li>
-                </ul>
-                <p></p>
+            <li>Open the <code class="fw-bold">X Menu</code> to pause the game.</li>
+            <p></p>
+            <li>Re-identify your current seed. Click <code class="fw-bold">Update Seeds</code> on the main window of owoow after re-identification, which will send your current seed to the active subwindow.</li>
+            <p></p>
+            <ul>
+                <li>If you are not within a few hundred advances of your target, use either of the "closer target" advancement methods listed in step 1 to advance the RNG state until you have reached the correct point. Be careful not to overshoot your target frame.</li>
+            </ul>
+            <p></p>
+            <li>Ensure that the <code class="fw-bold">Consider Menu Close?</code> checkbox is checked in the Digging Pa subwindow, and confirm that your NPC count has been calibrated and entered correctly. Search for your target again.</li>
+            <p></p>
+            <ul>
+                <li>Do not use the <code class="fw-bold">Holding Direction?</code> checkbox on owoow. Attempting to use direction hold will cause the NPC to activate and you will miss your target frame.</li>
+            </ul>
+            <p></p>
             <li>From this point, use <a class="clickable-image" data-image="https://raw.githubusercontent.com/Billo-PS/billo-guides-images/refs/heads/main/cfw/swsh/overworld/advancing-rng-state/animations.gif">attack animations</a> to reach the exact target frame. You can re-identify your current seed at any point if you wish.</li>
             <p></p>
             <li>Close the Pok&eacute;mon window so you are on the main <code class="fw-bold">X Menu</code>.</li>
             <p></p>
-            <li>Unpause the game by pressing B. Do not move the control stick when unpausing as we are trying to preserve an optimal NPC state.</li>
+            <li>Unpause the game by pressing B. Do not touch the joystick when unpausing or you can lose the deactivated NPC state.</li>
             <p></p>
             <li>Quickly interact with Digging Pa to lock in your hoard of Watts. Agree to trade him Armorite Ore and click A until he is exhausted.</li>
         </ol>

--- a/retail/swsh/item/loto-id/index.html
+++ b/retail/swsh/item/loto-id/index.html
@@ -59,13 +59,13 @@ permalink: /retail/swsh/item/loto-id/
         <ol>
             <li>At the top of the main owoow window, click <code class="fw-bold">Loto-ID</code> to open the Loto-ID generator in a subwindow.</li>
             <p></p>
-            <li>Enter the number of advances you want to search in the <code class="fw-bold">+</code> field. You will usually find any desired result in 100,000 advances or fewer.</li>
+            <li>Enter the number of advances you want to search in the <code class="fw-bold">+</code> field. You will usually find any desired result in under 100,000 advances.</li>
             <p></p>
             <li>Select your <code class="fw-bold">Target</code> reward from the drop-down menu. You can target Master Ball, Rare Candy, PP Max, PP Up, or Moomoo Milk.</li>
             <p></p>
             <li>Click the <code class="fw-bold">ID List</code> button to open the ID List. Add all the unique Trainer ID numbers of your deposited Pok&eacute;mon by entering each number in the <code class="fw-bold">ID:</code> field, then clicking <code class="fw-bold">Add</code>. The more IDs in this list, the greater the chance of finding an early result.</li>
             <p></p>
-            <li>Tick the <code class="fw-bold">Consider Menu Close?</code> checkbox, then enter the NPC count. if you are in Turffield, enter 7. If you are elsewhere, calibrate the NPCs yourself. You can now begin searching for targets.</li>
+            <li>Tick the <code class="fw-bold">Consider Menu Close?</code> checkbox, then enter the NPC count. If you are in Turffield, enter 7. If you are elsewhere, use the menu NPCs you calculated previously. You can now begin searching for targets.</li>
         </ol>
 
         <p>If you do not find any results, make sure you have IDs entered first. If you still do not find any results, you will need to increase your search range, change your search filters to be less restrictive, or reset the game for a better seed.</p>
@@ -96,25 +96,24 @@ permalink: /retail/swsh/item/loto-id/
                 <p></p>
             <li>Stop advancing once you are ~300-500 advances before your target. Give yourself more leeway if you have left your position or do not have a rough idea of how many advances have occured. If you have moved, reposition yourself in front of the Rotom PC so you can immediately interact with it.</li>
             <p></p>
-            <li>
-                Open the <code class="fw-bold">X Menu</code> to pause the game then re-identify your current seed. Click <code class="fw-bold">Update Seeds</code> on the main window of owoow after re-identification to reflect your current seed into the active subwindow.
-                <p></p>
-                <ul>
-                    <li>If you are not yet within a few hundred advances of your target, use either of the "closer target" advancement methods listed in step 1 to advance the RNG state until you have reached the correct point. Be careful as you do not want to overshoot your target frame.</li>
-                </ul>
-                <p></p>
-            <li>
-                Ensure that the <code class="fw-bold">Consider Menu Close?</code> checkbox is checked in the Loto-ID subwindow, and confirm that your NPC count has been calibrated and entered correctly. Search for your target again.
-                <p></p>
-                <ul>
-                    <li>Do not use the <code class="fw-bold">Holding Direction?</code> checkbox on owoow. This increases the difficulty of hitting your target frame as we are already standing next to the Rotom PC.</li>
-                </ul>
-                <p></p>
+            <li>Open the <code class="fw-bold">X Menu</code> to pause the game.</li>
+            <p></p>
+            <li>Re-identify your current seed. Click <code class="fw-bold">Update Seeds</code> on the main window of owoow after re-identification, which will send your current seed to the active subwindow.</li>
+            <ul>
+                <li>If you are not within a few hundred advances of your target, use either of the "closer target" advancement methods listed in step 1 to advance the RNG state until you have reached the correct point. Be careful not to overshoot your target frame.</li>
+            </ul>
+            <p></p>
+            <li>Ensure that the <code class="fw-bold">Consider Menu Close?</code> checkbox is checked in the Loto-ID subwindow, and confirm that your NPC count has been calibrated and entered correctly. Search for your target again.</li>
+            <p></p>
+            <ul>
+                <li>Do not use the <code class="fw-bold">Holding Direction?</code> checkbox on owoow. This increases the difficulty of hitting your target frame as we are already standing next to the Rotom PC.</li>
+            </ul>
+            <p></p>
             <li>From this point, use <a class="clickable-image" data-image="https://raw.githubusercontent.com/Billo-PS/billo-guides-images/refs/heads/main/cfw/swsh/overworld/advancing-rng-state/animations.gif">attack animations</a> to reach the exact target frame. You can re-identify your current seed at any point if you wish.</li>
             <p></p>
             <li>Close the Pok&eacute;mon window so you are on the main <code class="fw-bold">X Menu</code>.</li>
             <p></p>
-            <li>Unpause the game by pressing B. Do not move the control stick when unpausing as we are already positioned next to the Rotom PC.</li>
+            <li>Unpause the game by pressing B. Do not touch the joystick when unpausing as we are already positioned next to to the Rotom PC.</li>
             <p></p>
             <li>Quickly interact with the Rotom PC to lock your item result in place. Now select <code class="fw-bold">Try Loto-ID</code> to get your reward.</li>
         </ol>

--- a/retail/swsh/item/wailord-respawn/index.html
+++ b/retail/swsh/item/wailord-respawn/index.html
@@ -27,11 +27,15 @@ permalink: /retail/swsh/item/wailord-respawn/
     </div>
     <div class="card-body card-bg">
         <ol>
-            <li>Head to the Isle of Armor and enter the train station.</li>
+            <li>You will need to date skip so that Isle of Armor considers it a new day. The method you will use depends on if you have the ability to perform Link Battles, either locally or via NSO.</li>
             <p></p>
-            <li>Perform a date skip while standing in the train station.</li>
-            <p></p>
-            <li>Identify your seed and calibrate your menu NPC count; a common NPC value for the train station is 6.</li>
+            <ul>
+                <li>If you can activate the PvP date skipping exploit, head to the Isle of Armor, enter the train station, and perform a date skip this way.</li>
+                <p></p>
+                <li>If you cannot use a Link Battle, fly to the train station on IoA, perform a date skip using a nearby Max Raid den, and then walk or bike into the train station without reloading the map.</li>
+                <p></p>
+            </ul>
+            <li>Now that you are inside the Isle of Armor trains tation, identify your seed and calibrate your menu NPC count; a common NPC value for the train station is 6.</li>
             <p></p>
             <li>Save the game.</li>
         </ol>
@@ -78,7 +82,9 @@ permalink: /retail/swsh/item/wailord-respawn/
             <p></p>
             <li>Once you are roughly 100-200 advances before your target, stand close to the train station exit so that holding down on your joystick will cause your character to leave the station and trigger the loading screen.</li>
             <p></p>
-            <li>Open the <code class="fw-bold">X Menu</code> to pause the game then re-identify your current seed. Click <code class="fw-bold">Update Seeds</code> on the main window of owoow after re-identification to reflect your current seed into the active subwindow.</li>
+            <li>Open the <code class="fw-bold">X Menu</code> to pause the game.</li>
+            <p></p>
+            <li>Re-identify your current seed. Click <code class="fw-bold">Update Seeds</code> on the main window of owoow after re-identification, which will send your current seed to the active subwindow.</li>
             <p></p>
             <li>Ensure that the <code class="fw-bold">Consider Menu Close?</code> and <code class="fw-bold">Holding Direction?</code> checkboxes are checked in the Wailord Respawn subwindow, and confirm that your NPC count has been entered correctly. Search for your target again.</li>
             <p></p>

--- a/retail/swsh/item/watt-trader/index.html
+++ b/retail/swsh/item/watt-trader/index.html
@@ -43,10 +43,6 @@ permalink: /retail/swsh/item/watt-trader/
         <ol>
             <li>Set the weather in the <code class="fw-bold">Encounter Settings</code> section of the main owoow window to the current weather condition in Snowslide Slope.</li>
             <p></p>
-            <ul>
-                <li>Avoid using Rain/Thunderstorm. These weather conditions are not supported as they are unnecessarily more difficult for no advantage.</li>
-            </ul>
-            <p></p>
             <li>At the top of the main owoow window, click <code class="fw-bold">Watt Trader</code> to open the Watt Trader generator in a subwindow.</li>
             <p></p>
             <li>Enter your search filters, then enter the number of advances you want to search in the <code class="fw-bold">+</code> field. Usually you will find a result that produces a Dream/Beast Ball in 10,000 advances or fewer.</li>
@@ -74,9 +70,9 @@ permalink: /retail/swsh/item/watt-trader/
         <ol>
             <li>Head to the location in Snowslide Slope pictured above. If this is your first time, interact with the Watt Trader NPC at least once to unlock the fly point and complete his introduction.</li>
             <p></p>
-            <li>Verify the weather condition by opening the map. If the current weather is Rain/Thunderstorm, change the date so the weather is anything calm.</li>
+            <li>Verify the weather condition by checking the map. Ensure that this matches the setting in owoow.</li>
             <p></p>
-            <li>Move far enough away so that the NPC deactivates, you can tell if you are positioned correctly because they will turn and go back into their idle animation.</li>
+            <li>Move far enough away so that the NPC deactivates. You can tell if you are positioned correctly if he turns away and resumes his idle animation.</li>
             <p></p>
             <li>Identify your current seed at this stage. Now you will need to position yourself optimally. This is done with a movement technique that disrupts the NPCs "activation":</li>
             <p></p>
@@ -87,7 +83,7 @@ permalink: /retail/swsh/item/watt-trader/
                 <p></p>
                 <li>If you did this <a class="clickable-image" data-image="https://raw.githubusercontent.com/Billo-PS/billo-guides-images/refs/heads/main/cfw/swsh/item/watt-trader/incorrect-setup.gif">incorrectly</a>, the NPC will activate after backing out of the dialogue, causing the usual, extremely fast NPC activation advances we normally use for advancing the RNG state.</li>
                 <p></p>
-                <li>If you are unsure of your NPC state you can wait about 10 seconds and re-identify your seed. If you are noticing that ~1000 advances have occurred then you are NOT positioned correctly. Move away from the NPC and try again.</li>
+                <li>If you are unsure of your NPC state, you can wait about 10 seconds and re-identify your seed. If over 1000 advances have occurred, then you are NOT positioned correctly. Move away from the NPC and try again.</li>
                 <p></p>
                 <li>It may take a few attempts to get the NPC into the correct state, but this provides the most stable experience possible for this type of RNG manipulation.</li>
             </ul>
@@ -96,7 +92,7 @@ permalink: /retail/swsh/item/watt-trader/
             <p></p>
             <li>Perform a date skip to refresh the daily highlight item. This can be done using the Raid exploit or PvP date skipping exploit.</li>
             <p></p>
-            <li>Save the game. This will preserve the current NPC state upon resetting as long as you reopen the game on the same date or an earlier date. Do not speak to the NPC again until you reach your target frame.</li>
+            <li>Save the game. This will preserve the current deactivated NPC state through resets. The menu NPC count will also remain long as you reopen the game on the same date or an earlier date.</li>
         </ol>
     </div>
 </div>
@@ -133,27 +129,27 @@ permalink: /retail/swsh/item/watt-trader/
                     <li>For closer targets, consider using <a class="clickable-image" data-image="https://raw.githubusercontent.com/Billo-PS/billo-guides-images/refs/heads/main/cfw/swsh/overworld/advancing-rng-state/bike-mount.gif">bike hopping</a> or <a class="clickable-image" data-image="https://raw.githubusercontent.com/Billo-PS/billo-guides-images/refs/heads/main/cfw/swsh/overworld/advancing-rng-state/menu-close.gif">menu close</a>.</li>
                 </ul>
                 <p></p>
-            <li>Stop advancing once you are ~300-500 advances before your target. Give yourself if you do not have a rough idea of how many advances have occured.</li>
+            <li>Stop advancing once you are ~300-500 advances before your target. Give yourself extra leeway if you do not have a rough idea of how many advances have occurred.</li>
             <p></p>
-            <li>
-                Open the <code class="fw-bold">X Menu</code> to pause the game then re-identify your current seed. Click <code class="fw-bold">Update Seeds</code> on the main window of owoow after re-identification to reflect your current seed into the active subwindow.
-                <p></p>
-                <ul>
-                    <li>If you are not yet within a few hundred advances of your target, use the advancement methods listed in step 1 to advance the RNG state until you have reached the correct point. Be careful as you do not want to overshoot your target frame.</li>
-                </ul>
-                <p></p>
-            <li>
-                Ensure that the <code class="fw-bold">Consider Menu Close?</code> checkbox is checked in the Watt Trader subwindow, and confirm that your NPC count has been calibrated and entered correctly. Search for your target again.
-                <p></p>
-                <ul>
-                    <li>Do not use the <code class="fw-bold">Holding Direction?</code> checkbox on owoow. Attempting to use direction hold will cause the NPC to activate and you will miss your target frame.</li>
-                </ul>
-                <p></p>
+            <li>Open the <code class="fw-bold">X Menu</code> to pause the game.</li>
+            <p></p>
+            <li>Re-identify your current seed. Click <code class="fw-bold">Update Seeds</code> on the main window of owoow after re-identification, which will send your current seed to the active subwindow.</li>
+            <p></p>
+            <ul>
+                <li>If you are not within a few hundred advances of your target, use either of the "closer target" advancement methods listed in step 1 to advance the RNG state until you have reached the correct point. Be careful not to overshoot your target frame.</li>
+            </ul>
+            <p></p>
+            <li>Ensure that the <code class="fw-bold">Consider Menu Close?</code> checkbox is checked in the Watt Trader subwindow, and confirm that your NPC count has been calibrated and entered correctly. Search for your target again.</li>
+            <p></p>
+            <ul>
+                <li>Do not use the <code class="fw-bold">Holding Direction?</code> checkbox on owoow. Attempting to use direction hold will cause the NPC to activate and you will miss your target frame.</li>
+            </ul>
+            <p></p>
             <li>From this point, use <a class="clickable-image" data-image="https://raw.githubusercontent.com/Billo-PS/billo-guides-images/refs/heads/main/cfw/swsh/overworld/advancing-rng-state/animations.gif">attack animations</a> to reach the exact target frame. You can re-identify your current seed at any point if you wish.</li>
             <p></p>
             <li>Close the Pok&eacute;mon window so you are on the main <code class="fw-bold">X Menu</code>.</li>
             <p></p>
-            <li>Unpause the game by pressing B. Do not move the control stick when unpausing as we are trying to preserve an optimal NPC state.</li>
+            <li>Unpause the game by pressing B. Do not touch the joystick when unpausing or you can lose the deactivated NPC state.</li>
             <p></p>
             <li>Quickly interact with the Watt Trader to lock in your desired item. To access your desired highlight item follow the steps directly below.</li>
         </ol>

--- a/retail/swsh/overworld/roaming/dry.html
+++ b/retail/swsh/overworld/roaming/dry.html
@@ -19,14 +19,38 @@
         </thead>
         <tbody>
             <tr>
-                <td class="text-center">46</td>
+                <td class="text-center">43-47 (see below)</td>
                 <td class="text-center">0</td>
                 <td class="text-center">0</td>
             </tr>
         </tbody>
     </table>
 
-    <p><span class="fw-bold">Note -</span> As mentioned above, you must Virizion caught or must not have progressed the footprint story quest enough to spawn Virizion in the otherworld. Having Virizion spawned will produce results not found inside the table.</p>
+    <div class="card border-dark">
+        <div class="anchored card-header text-light" style="background-color: #0c0038;" id="articuno-area-load-calibration">
+            <span class="fw-bold">Articuno Area Load Calibration</span>
+        </div>
+        <div class="card-body card-bg">
+            <p>An additional calibration for the <code class="fw-bold">Area Load</code> value is needed for Galarian Articuno. This value represents the total number of strong spawns that are loaded in the area and distantly (e.g. birds and IoA Wailord). Normally, this would be constant after a date skip, but the strong spawn Audino in the area only respawn at a 10% rate each new day when you first load the map. If any are missing when you are performing the RNG manipulation, this will cause your predictions to be inaccurate.</p>
+
+            <p>For this calibration, you will need to go to all 3 locations for the Audino and take note of which ones are spawning. Note that Audino has flee behavior, so if you scare one away, do not count it.</p>
+
+            <p><a href="https://www.youtube.com/watch?v=skRsVjEujEI">Video of Giant's Bed Audino Locations</a></p>
+
+            <p>The final <code class="fw-bold">Area Load</code> value should be calculated like so:
+            <ol>
+                <li>Start with 43.</li>
+                <p></p>
+                <li>Add the number of Audino that are loaded, which will be +1, +2, or +3.</li>
+                <p></p>
+                <li>Add 1 if Virizion is spawning.</li>
+            </ol></p>
+
+            <p>You should get a number from 43-47. Put the final value in the <code class="fw-bold">Area Load</code> box.</p>
+
+            <p>If you have any missing Audino and date skip, you will need to count them again before performing your RNG manipulation attempt.</p>
+        </div>
+    </div>
 </div>
 
 <div class="bird bird-zapdos d-none">

--- a/retail/swsh/overworld/roaming/index.html
+++ b/retail/swsh/overworld/roaming/index.html
@@ -49,7 +49,6 @@ permalink: /retail/swsh/overworld/roaming/
             <p></p>
             <li>Adjust your search range using the <code class="fw-bold">+</code> field in <code class="fw-bold">Encounter Settings</code>, then configure additional search filters such as Marks, IVs, or Height.</li>
         </ol>
-
     </div>
 </div>
 <br />
@@ -99,15 +98,10 @@ permalink: /retail/swsh/overworld/roaming/
                 <p></p>
                 <li>For Moltres, speak to the NPC inside the <a class="clickable-image" data-image="https://raw.githubusercontent.com/Billo-PS/billo-guides-images/refs/heads/main/cfw/swsh/overworld/roaming/dojo-npc.png">Dojo</a>.</li>
             </ul>
-
         </ol>
     </div>
 </div>
 <br>
-
-<div class="alert alert-danger" style="border: 1px solid #b60606; border-radius: 8px; padding: 15px; background-color: #f8d7da; color: #721c24;">
-    <span class="fw-bold">Important -</span> For Articuno, you must not be at a point in Sonia's footprint sidequest where Virizion spawns in the overworld. Either wait to talk to Sonia to activate Virizion or capture it to clear it from the field. When Virizion is actively spawning in the overworld, this causes additional RNG calls that are not accounted for by owoow. (Virizion can be RNG manipulated using the <a href="https://billo-guides.github.io/retail/swsh/overworld/static/">Overworld Static RNG Manipulation</a> guide!)
-</div>
 
 <p><span class="fw-bold">Figure 3 -</span> Fondly Memory Demonstration</p>
 <img src="https://raw.githubusercontent.com/Billo-PS/billo-guides-images/refs/heads/main/cfw/swsh/overworld/roaming/fondly-memory.png" alt="owrng-roaming-3" class="img-fluid clickable-image" data-image="https://raw.githubusercontent.com/Billo-PS/billo-guides-images/refs/heads/main/cfw/swsh/overworld/roaming/fondly-memory.png"><p></p>
@@ -205,7 +199,6 @@ permalink: /retail/swsh/overworld/roaming/
         <p>The calibration values (<code class="fw-bold">Consider Menu Close?</code> / <code class="fw-bold">Menu Close NPCs</code> <code class="fw-bold">Area Load</code> / <code class="fw-bold">Fly NPCs</code> / <code class="fw-bold">Rain Ticks</code>) will account for the advances consumed when exiting from the party list -> main pause menu -> opening map -> flying into the area that contains your bird.</p>
 
         <p><span class="fw-bold">After correctly setting your calibration values, you can begin searching for targets.</span></p>
-
     </div>
 </div>
 <br>

--- a/retail/swsh/overworld/roaming/wet.html
+++ b/retail/swsh/overworld/roaming/wet.html
@@ -25,7 +25,7 @@
         </thead>
         <tbody>
             <tr>
-                <td class="text-center">46</td>
+                <td class="text-center">43-47 (see below)</td>
                 <td class="text-center">7/8</td>
                 <td class="text-center">14/16</td>
                 <td class="text-center">3</td>
@@ -35,8 +35,31 @@
         </tbody>
     </table>
 
+    <div class="card border-dark">
+        <div class="anchored card-header text-light" style="background-color: #0c0038;" id="articuno-area-load-calibration">
+            <span class="fw-bold">Articuno Area Load Calibration</span>
+        </div>
+        <div class="card-body card-bg">
+            <p>An additional calibration for the <code class="fw-bold">Area Load</code> value is needed for Galarian Articuno. This value represents the total number of strong spawns that are loaded in the area and distantly (e.g. birds and IoA Wailord). Normally, this would be constant after a date skip, but the strong spawn Audino in the area only respawn at a 10% rate each new day when you first load the map. If any are missing when you are performing the RNG manipulation, this will cause your predictions to be inaccurate.</p>
 
-    <p><span class="fw-bold">Note -</span> As mentioned above, you must Virizion caught or must not have progressed the footprint story quest enough to spawn Virizion in the otherworld. Having Virizion spawned will produce results not found inside the table.</p>
+            <p>For this calibration, you will need to go to all 3 locations for the Audino and take note of which ones are spawning. Note that Audino has flee behavior, so if you scare one away, do not count it.</p>
+
+            <p><a href="https://www.youtube.com/watch?v=skRsVjEujEI">Video of Giant's Bed Audino Locations</a></p>
+
+            <p>The final <code class="fw-bold">Area Load</code> value should be calculated like so:
+            <ol>
+                <li>Start with 43.</li>
+                <p></p>
+                <li>Add the number of Audino that are loaded, which will be +1, +2, or +3.</li>
+                <p></p>
+                <li>Add 1 if Virizion is spawning.</li>
+            </ol></p>
+
+            <p>You should get a number from 43-47. Put the final value in the <code class="fw-bold">Area Load</code> box.</p>
+
+            <p>If you have any missing Audino and date skip, you will need to count them again before performing your RNG manipulation attempt.</p>
+        </div>
+    </div>
 </div>
 
 <div class="bird bird-zapdos d-none">


### PR DESCRIPTION
Made all the SWSH Item Guides consistent between each other, and tweaked some wording.

Adds the Audino calibration explanation to all Galarian Articuno tables.

Removes the old advice to despawn Virizion.