### PR TITLE
Riding bike must be consistent between calibration and manipulation

### DIFF
--- a/cfw/swsh/overworld/fishing/wet.html
+++ b/cfw/swsh/overworld/fishing/wet.html
@@ -16,6 +16,7 @@
             <li>Stand as close as possible to the fishing pool without spawning it in. Save the game once you are in this position. Do not reposition yourself after this point.</li>
             <ul>
                 <li>One method to do this is to tap the joystick towards the fishing pool and save the game each time it does not spawn. The target position is such that a single, gentle tap immediately spawns the fishing pool.</li>
+                <li>If you plan to perform the RNG manipulation on a bike, you should make sure you are calibrating rain ticks while on the bike.</li>
             </ul>
             <li>Calibrate your NPC count in any weather that is NOT Rain or Thunderstorm. After you close the <code class="fw-bold">MenuCloseTimeline</code> subwindow, verify that your NPC count has been entered into the main window and you have checked both the <code class="fw-bold">Consider Menu Close?</code> and <code span class="fw-bold">Holding Direction?</code> checkboxes.</li>
             <li>Ensure the <code class="fw-bold">Consider Menu Close?</code> and <code class="fw-bold">Holding Direction?</code> checkboxes are enabled in the main window, and enter your calibrated NPC count in the <code class="fw-bold">NPCs</code> field.</li>
@@ -65,6 +66,9 @@
             <li>Confirm that the <code class="fw-bold">Consider Menu Close?</code> &amp; <code class="fw-bold">Holding Direction?</code> boxes have been checked, and that your NPC count and Rain Ticks have been entered properly.</li>
             <li>Advance toward your target using <a class="clickable-image" data-image="https://raw.githubusercontent.com/Billo-PS/billo-guides-images/refs/heads/main/cfw/swsh/overworld/advancing-rng-state/wet-weather.gif">wet weather</a> or <a class="clickable-image" data-image="https://raw.githubusercontent.com/Billo-PS/billo-guides-images/refs/heads/main/cfw/swsh/overworld/advancing-rng-state/date-skipping.gif">date skipping</a> to maintain your position and Rain Tick calibration. Do NOT move the player.</li>
             <li>Monitor your progress while advancing to avoid overshooting. Stop advancing once you are about 1000 frames before your target. Open the <code class="fw-bold">X Menu</code> to pause the game.</li>
+            <ul>
+                <li>If you calibrated  rain ticks while on the bike, make sure you are on the bike before you open the <code class="fw-bold">X Menu</code>. If you calibrated them while on foot, then you should be on foot.</li>
+            </ul>
             <li>Use <a class="clickable-image" data-image="https://raw.githubusercontent.com/Billo-PS/billo-guides-images/refs/heads/main/cfw/swsh/overworld/advancing-rng-state/wet-weather-menuing.gif">wet weather menuing</a> until you are about 100-300 away from your target. Open the Pok&eacute;mon party list.</li>
             <li>Click <code class="fw-bold">Update Seeds</code> in owoow to reset your advances to 0.</li>
             <li><span class="fw-bold">You should be on the Pok&eacute;mon party list, not a Pok&eacute;mon summary page!</span> Use <a class="clickable-image" data-image="https://raw.githubusercontent.com/Billo-PS/billo-guides-images/refs/heads/main/cfw/swsh/overworld/advancing-rng-state/animations.gif">attack animations</a> to reach the exact target frame. Stay on the Pok&eacute;mon party list menu when done.</li>

--- a/cfw/swsh/overworld/static/wet.html
+++ b/cfw/swsh/overworld/static/wet.html
@@ -16,6 +16,7 @@
             <li>Stand as close as possible to the Pok&eacute;mon spawner without spawning it in. Save the game once you are in this position. Do not reposition yourself after this point.</li>
             <ul>
                 <li>One method to do this is to tap the joystick towards the Pok&eacute;mon and save the game each time it does not spawn. The target position is such that a single, gentle tap immediately spawns the Pok&eacute;mon.</li>
+                <li>If you plan to perform the RNG manipulation on a bike, you should make sure you are calibrating rain ticks while on the bike.</li>
             </ul>
             <li>Calibrate your NPC count in any weather that is NOT Rain or Thunderstorm. After you close the <code class="fw-bold">MenuCloseTimeline</code> subwindow, verify that your NPC count has been entered into the main window and you have checked both the <code class="fw-bold">Consider Menu Close?</code> and <code span class="fw-bold">Holding Direction?</code> checkboxes.</li>
             <li>Ensure the <code class="fw-bold">Consider Menu Close?</code> and <code class="fw-bold">Holding Direction?</code> checkboxes are enabled in the main window, and enter your calibrated NPC count in the <code class="fw-bold">NPCs</code> field.</li>
@@ -65,6 +66,9 @@
             <li>Confirm that the <code class="fw-bold">Consider Menu Close?</code> &amp; <code class="fw-bold">Holding Direction?</code> boxes have been checked, and that your NPC count and Rain Ticks have been entered properly.</li>
             <li>Advance toward your target using <a class="clickable-image" data-image="https://raw.githubusercontent.com/Billo-PS/billo-guides-images/refs/heads/main/cfw/swsh/overworld/advancing-rng-state/wet-weather.gif">wet weather</a> or <a class="clickable-image" data-image="https://raw.githubusercontent.com/Billo-PS/billo-guides-images/refs/heads/main/cfw/swsh/overworld/advancing-rng-state/date-skipping.gif">date skipping</a> to maintain your position and Rain Tick calibration. Do NOT move the player.</li>
             <li>Monitor your progress while advancing to avoid overshooting. Stop advancing once you are about 1000 frames before your target. Dismount from your bike. Open the <code class="fw-bold">X Menu</code> to pause the game.</li>
+            <ul>
+                <li>If you calibrated  rain ticks while on the bike, make sure you are on the bike before you open the <code class="fw-bold">X Menu</code>. If you calibrated them while on foot, then you should be on foot.</li>
+            </ul>
             <li>Use <a class="clickable-image" data-image="https://raw.githubusercontent.com/Billo-PS/billo-guides-images/refs/heads/main/cfw/swsh/overworld/advancing-rng-state/wet-weather-menuing.gif">wet weather menuing</a> until you are about 100-300 away from your target. Open the Pok&eacute;mon party list.</li>
             <li>Click <code class="fw-bold">Update Seeds</code> in owoow to reset your advances to 0.</li>
             <li><span class="fw-bold">You should be on the Pok&eacute;mon party list, not a Pok&eacute;mon summary page!</span> Use <a class="clickable-image" data-image="https://raw.githubusercontent.com/Billo-PS/billo-guides-images/refs/heads/main/cfw/swsh/overworld/advancing-rng-state/animations.gif">attack animations</a> to reach the exact target frame. Stay on the Pok&eacute;mon party list menu when done.</li>

--- a/cfw/swsh/overworld/symbol/wet.html
+++ b/cfw/swsh/overworld/symbol/wet.html
@@ -16,6 +16,7 @@
             <li>Stand as close as possible to the Pok&eacute;mon spawner without spawning it in. Save the game once you are in this position. Do not reposition yourself after this point.</li>
             <ul>
                 <li>One method to do this is to tap the joystick towards the Pok&eacute;mon and save the game each time it does not spawn. The target position is such that a single, gentle tap immediately spawns the Pok&eacute;mon.</li>
+                <li>If you plan to perform the RNG manipulation on a bike, you should make sure you are calibrating rain ticks while on the bike.</li>
             </ul>
             <li>Calibrate your NPC count in any weather that is NOT Rain or Thunderstorm. After you close the <code class="fw-bold">MenuCloseTimeline</code> subwindow, verify that your NPC count has been entered into the main window and you have checked both the <code class="fw-bold">Consider Menu Close?</code> and <code span class="fw-bold">Holding Direction?</code> checkboxes.</li>
             <li>Ensure the <code class="fw-bold">Consider Menu Close?</code> and <code class="fw-bold">Holding Direction?</code> checkboxes are enabled in the main window, and enter your calibrated NPC count in the <code class="fw-bold">NPCs</code> field.</li>
@@ -66,6 +67,9 @@
             <li>Confirm that the <code class="fw-bold">Consider Menu Close?</code> &amp; <code class="fw-bold">Holding Direction?</code> boxes have been checked, and that your NPC count and Rain Ticks have been entered properly.</li>
             <li>Advance toward your target using <a class="clickable-image" data-image="https://raw.githubusercontent.com/Billo-PS/billo-guides-images/refs/heads/main/cfw/swsh/overworld/advancing-rng-state/wet-weather.gif">wet weather</a> or <a class="clickable-image" data-image="https://raw.githubusercontent.com/Billo-PS/billo-guides-images/refs/heads/main/cfw/swsh/overworld/advancing-rng-state/date-skipping.gif">date skipping</a> to maintain your position and Rain Tick calibration. Do NOT move the player.</li>
             <li>Monitor your progress while advancing to avoid overshooting. Stop advancing once you are about 1000 frames before your target. Open the <code class="fw-bold">X Menu</code> to pause the game.</li>
+            <ul>
+                <li>If you calibrated  rain ticks while on the bike, make sure you are on the bike before you open the <code class="fw-bold">X Menu</code>. If you calibrated them while on foot, then you should be on foot.</li>
+            </ul>
             <li>Use <a class="clickable-image" data-image="https://raw.githubusercontent.com/Billo-PS/billo-guides-images/refs/heads/main/cfw/swsh/overworld/advancing-rng-state/wet-weather-menuing.gif">wet weather menuing</a> until you are about 100-300 away from your target. Open the Pok&eacute;mon party list.</li>
             <li>Click <code class="fw-bold">Update Seeds</code> in owoow to reset your advances to 0.</li>
             <li><span class="fw-bold">You should be on the Pok&eacute;mon party list, not a Pok&eacute;mon summary page!</span> Use <a class="clickable-image" data-image="https://raw.githubusercontent.com/Billo-PS/billo-guides-images/refs/heads/main/cfw/swsh/overworld/advancing-rng-state/animations.gif">attack animations</a> to reach the exact target frame. Stay on the Pok&eacute;mon party list menu when done.</li>

--- a/retail/swsh/overworld/fishing/wet.html
+++ b/retail/swsh/overworld/fishing/wet.html
@@ -17,6 +17,7 @@
             <li>Stand as close as possible to the fishing pool without spawning it in. Save the game once you are in this position. Do not reposition yourself after this point.</li>
             <ul>
                 <li>One method to do this is to tap the joystick towards the fishing pool and save the game each time it does not spawn. The target position is such that a single, gentle tap immediately spawns the fishing pool.</li>
+                <li>If you plan to perform the RNG manipulation on a bike, you should make sure you are calibrating rain ticks while on the bike.</li>
             </ul>
             <li>Pause the game by opening the menu and identify your seed using the <code span class="fw-bold">Retail Seed Finder</code>.</li>
             <li>Calibrate your NPC count in any weather that is NOT Rain or Thunderstorm. After you close the <code class="fw-bold">MenuCloseTimeline</code> subwindow, verify that your NPC count has been entered into the main window and you have checked both the <code class="fw-bold">Consider Menu Close?</code> and <code span class="fw-bold">Holding Direction?</code> checkboxes.</li>
@@ -66,6 +67,9 @@
             <li>Confirm that the <code class="fw-bold">Consider Menu Close?</code> &amp; <code class="fw-bold">Holding Direction?</code> boxes have been checked, and that your NPC count and Rain Ticks have been entered properly.</li>
             <li>Advance towards your target using <a class="clickable-image" data-image="https://raw.githubusercontent.com/Billo-PS/billo-guides-images/refs/heads/main/cfw/swsh/overworld/advancing-rng-state/wet-weather.gif">wet weather</a> or <a href="/retail/swsh/overworld/advancing-the-rng-state#advancements-method-date-skipping" target="_blank">date skipping</a> to maintain your current positioning and Rain Tick calibration. Do NOT move the player.</li>
             <li>Reidentify your seed periodically to avoid overshooting. Stop advancing once you are about 1000 frames before your target. Dismount from your bike. Open the <code class="fw-bold">X Menu</code> to pause the game.</li>
+            <ul>
+                <li>If you calibrated  rain ticks while on the bike, make sure you are on the bike before you open the <code class="fw-bold">X Menu</code>. If you calibrated them while on foot, then you should be on foot.</li>
+            </ul>
             <li>Use <a class="clickable-image" data-image="https://raw.githubusercontent.com/Billo-PS/billo-guides-images/refs/heads/main/cfw/swsh/overworld/advancing-rng-state/wet-weather-menuing.gif">wet weather menuing</a> until you are about 100-300 away from your target. Open the Pok&eacute;mon party list.</li>
             <li>Reidentify your seed on this screen and search for your target frame again. This should reset your advances to 0.</li>
             <li><span class="fw-bold">You should be on the Pok&eacute;mon party list, not a Pok&eacute;mon summary page!</span> Use <a class="clickable-image" data-image="https://raw.githubusercontent.com/Billo-PS/billo-guides-images/refs/heads/main/cfw/swsh/overworld/advancing-rng-state/animations.gif">attack animations</a> to reach the exact target frame. Each <code class="fw-bold">L3</code> button input on the party list advances the RNG state by +1 (e.g., 100 inputs = 100 advances). Stay on the Pok&eacute;mon party list menu when done.</li>

--- a/retail/swsh/overworld/static/wet.html
+++ b/retail/swsh/overworld/static/wet.html
@@ -17,6 +17,7 @@
             <li>Stand as close as possible to the Pok&eacute;mon spawner without spawning it in. Save the game once you are in this position. Do not reposition yourself after this point.</li>
             <ul>
                 <li>One method to do this is to tap the joystick towards the Pok&eacute;mon and save the game each time it does not spawn. The target position is such that a single, gentle tap immediately spawns the Pok&eacute;mon.</li>
+                <li>If you plan to perform the RNG manipulation on a bike, you should make sure you are calibrating rain ticks while on the bike.</li>
             </ul>
             <li>Pause the game by opening the menu and identify your seed using the <code span class="fw-bold">Retail Seed Finder</code>.</li>
             <li>Calibrate your NPC count in any weather that is NOT Rain or Thunderstorm. After you close the <code class="fw-bold">MenuCloseTimeline</code> subwindow, verify that your NPC count has been entered into the main window and you have checked both the <code class="fw-bold">Consider Menu Close?</code> and <code span class="fw-bold">Holding Direction?</code> checkboxes.</li>
@@ -66,6 +67,9 @@
             <li>Confirm that the <code class="fw-bold">Consider Menu Close?</code> &amp; <code class="fw-bold">Holding Direction?</code> boxes have been checked, and that your NPC count and Rain Ticks have been entered properly.</li>
             <li>Advance towards your target using <a class="clickable-image" data-image="https://raw.githubusercontent.com/Billo-PS/billo-guides-images/refs/heads/main/cfw/swsh/overworld/advancing-rng-state/wet-weather.gif">wet weather</a> or <a href="/retail/swsh/overworld/advancing-the-rng-state#advancements-method-date-skipping" target="_blank">date skipping</a> to maintain your current positioning and Rain Tick calibration. Do NOT move the player.</li>
             <li>Reidentify your seed periodically to avoid overshooting. Stop advancing once you are about 1000 frames before your target. Open the <code class="fw-bold">X Menu</code> to pause the game.</li>
+            <ul>
+                <li>If you calibrated  rain ticks while on the bike, make sure you are on the bike before you open the <code class="fw-bold">X Menu</code>. If you calibrated them while on foot, then you should be on foot.</li>
+            </ul>
             <li>Use <a class="clickable-image" data-image="https://raw.githubusercontent.com/Billo-PS/billo-guides-images/refs/heads/main/cfw/swsh/overworld/advancing-rng-state/wet-weather-menuing.gif">wet weather menuing</a> until you are about 100-300 away from your target. Open the Pok&eacute;mon party list.</li>
             <li>Reidentify your seed on this screen and search for your target frame again. This should reset your advances to 0.</li>
             <li><span class="fw-bold">You should be on the Pok&eacute;mon party list, not a Pok&eacute;mon summary page!</span> Use <a class="clickable-image" data-image="https://raw.githubusercontent.com/Billo-PS/billo-guides-images/refs/heads/main/cfw/swsh/overworld/advancing-rng-state/animations.gif">attack animations</a> to reach the exact target frame. Each <code class="fw-bold">L3</code> button input on the party list advances the RNG state by +1 (e.g., 100 inputs = 100 advances). Stay on the Pok&eacute;mon party list menu when done.</li>

--- a/retail/swsh/overworld/symbol/wet.html
+++ b/retail/swsh/overworld/symbol/wet.html
@@ -17,6 +17,7 @@
             <li>Stand as close as possible to the Pok&eacute;mon spawner without spawning it in. Save the game once you are in this position. Do not reposition yourself after this point.</li>
             <ul>
                 <li>One method to do this is to tap the joystick towards the Pok&eacute;mon and save the game each time it does not spawn. The target position is such that a single, gentle tap immediately spawns the Pok&eacute;mon.</li>
+                <li>If you plan to perform the RNG manipulation on a bike, you should make sure you are calibrating rain ticks while on the bike.</li>
             </ul>
             <li>Pause the game by opening the menu and identify your seed using the <code span class="fw-bold">Retail Seed Finder</code>.</li>
             <li>Calibrate your NPC count in any weather that is NOT Rain or Thunderstorm. After you close the <code class="fw-bold">MenuCloseTimeline</code> subwindow, verify that your NPC count has been entered into the main window and you have checked both the <code class="fw-bold">Consider Menu Close?</code> and <code span class="fw-bold">Holding Direction?</code> checkboxes.</li>
@@ -67,6 +68,9 @@
             <li>Confirm that the <code class="fw-bold">Consider Menu Close?</code> &amp; <code class="fw-bold">Holding Direction?</code> boxes have been checked, and that your NPC count and Rain Ticks have been entered properly.</li>
             <li>Advance towards your target using <a class="clickable-image" data-image="https://raw.githubusercontent.com/Billo-PS/billo-guides-images/refs/heads/main/cfw/swsh/overworld/advancing-rng-state/wet-weather.gif">wet weather</a> or <a href="/retail/swsh/overworld/advancing-the-rng-state#advancements-method-date-skipping" target="_blank">date skipping</a> to maintain your current positioning and Rain Tick calibration. Do NOT move the player.</li>
             <li>Reidentify your seed periodically to avoid overshooting. Stop advancing once you are about 1000 frames before your target. Open the <code class="fw-bold">X Menu</code> to pause the game.</li>
+            <ul>
+                <li>If you calibrated  rain ticks while on the bike, make sure you are on the bike before you open the <code class="fw-bold">X Menu</code>. If you calibrated them while on foot, then you should be on foot.</li>
+            </ul>
             <li>Use <a class="clickable-image" data-image="https://raw.githubusercontent.com/Billo-PS/billo-guides-images/refs/heads/main/cfw/swsh/overworld/advancing-rng-state/wet-weather-menuing.gif">wet weather menuing</a> until you are about 100-300 away from your target. Open the Pok&eacute;mon party list.</li>
             <li>Reidentify your seed on this screen and search for your target frame again. This should reset your advances to 0.</li>
             <li><span class="fw-bold">You should be on the Pok&eacute;mon party list, not a Pok&eacute;mon summary page!</span> Use <a class="clickable-image" data-image="https://raw.githubusercontent.com/Billo-PS/billo-guides-images/refs/heads/main/cfw/swsh/overworld/advancing-rng-state/animations.gif">attack animations</a> to reach the exact target frame. Each <code class="fw-bold">L3</code> button input on the party list advances the RNG state by +1 (e.g., 100 inputs = 100 advances). Stay on the Pok&eacute;mon party list menu when done.</li>


### PR DESCRIPTION
Remind users that if they want to do rain RNG on a bike, they must calibrate rain ticks on a bike. Same goes for doing it on foot.