### PR TITLE
Small Improvements

### DIFF
--- a/archives/cfw/old-overworld/index.html
+++ b/archives/cfw/old-overworld/index.html
@@ -166,7 +166,7 @@ permalink: /cfw/swsh/old-overworld
 <br>
 
 <hr /><div class="title" style="background-color: #0c0038;">
-    <h1 class="text-light text-center pt-3 pb-3">Advancing The RNG State</h1>
+    <h1 class="text-light text-center pt-3 pb-3">Advancing the RNG State</h1>
 </div>
 <hr />
 

--- a/archives/retail/old-overworld/index.html
+++ b/archives/retail/old-overworld/index.html
@@ -211,7 +211,7 @@ permalink: /retail/swsh/old-overworld
 <p>Menu Close prediction is the recommended method used to hit target frames and is referenced multiple times throughout this guide. It is highly recommended to become familiar with the process of calibrating NPC counts before continuing.</p>
 
 <hr /><div class="title" style="background-color: #0c0038;">
-    <h1 class="text-light text-center pt-3 pb-3">Advancing The RNG State</h1>
+    <h1 class="text-light text-center pt-3 pb-3">Advancing the RNG State</h1>
 </div>
 <hr />
 

--- a/cfw/bdsp/index.html
+++ b/cfw/bdsp/index.html
@@ -90,9 +90,28 @@ permalink: /cfw/bdsp/
     <h1 class="text-light text-center pt-3 pb-3">Software Installation &amp; Setup</h1>
 </div>
 <small class="text-muted mb-3 mt-0">
-    This section provides installation and setup instructions, follow this information carefully.
+    This section provides setup and installation instructions for PC and Switch software.
 </small>
 <hr />
+
+<div class="alert alert-danger" style="border: 1px solid #a80404; border-radius: 8px; padding: 15px; background-color: #f8d7da; color: #721c24;">
+    <span class="fw-bold">Important -</span> Remove all mods and cheats for BDSP before proceeding. Mods/cheats can alter the RNG of the games and cause RAM reads to fail.
+
+    <p></p>
+    <p>Switch mods/cheats are stored in the <code span class="fw-bold">atmosphere/contents</code> directory on your SD card. This folder is typically empty on a fresh installation of Atmosph&egrave;re.</p>
+
+    <details>
+        <summary><span class="fw-bold">Methods for Disabling Mods/Cheats</span></summary>
+        <p>Any of these methods can work to disable mods/cheats. You should select the best one for your use case.</p>
+
+        <ul>
+            <li>Rename the <code span class="fw-bold">atmosphere/contents</code> folder to something else, such as <code span class="fw-bold">oldcontents</code>. This will allow you to keep everything you previously installed. You can simply rename the folder back when done.</li>
+            <li>Delete the <code span class="fw-bold">atmosphere/contents</code> folder. This may be a good option if you have many files in this directory that you do not recognize and you want to clean out your SD card.</li>
+            <li>Delete specific mods/cheats from the <code span class="fw-bold">atmosphere/contents</code> folder. This requires you to know which title ID corresponds to what.</li>
+            <li>If you wish to keep the <code span class="fw-bold">atmosphere/contents</code> folder intact, you can hold <code span class="fw-bold">L</code> every time you boot the game.</li>
+        </ul>
+    </details>
+</div>
 
 <div class="card border-dark">
     <div class="anchored card-header" style="background-color: #96324c;" id="setup-and-install-bdsp-cfw">
@@ -105,7 +124,7 @@ permalink: /cfw/bdsp/
             <li><a href="/misc/downloads/moarencounterbots.zip" download>SysBot.NET - Moarencounterbots</a></li>
             <li><a href="https://github.com/zyro670/PokeViewer.NET" target="_blank">PokeViewer.NET</a></li>
             <li><a href="https://github.com/olliz0r/sys-botbase/releases/" target="_blank">sys-botbase</a></li>
-            <li><a href="https://github.com/olliz0r/sys-botbase/releases/" target="_blank">LINQPad</a> (Pok&eacute;Radar only)</li>
+            <li><a href="https://www.linqpad.net/download.aspx" target="_blank">LINQPad</a> (Pok&eacute;Radar only)</li>
         </ul>
 
         <h6><span class="fw-bold">Installation Instructions</span></h6>

--- a/cfw/la/legendary/index.html
+++ b/cfw/la/legendary/index.html
@@ -62,6 +62,25 @@ permalink: /cfw/la/legendary/
 </small>
 <hr />
 
+<div class="alert alert-danger" style="border: 1px solid #a80404; border-radius: 8px; padding: 15px; background-color: #f8d7da; color: #721c24;">
+    <span class="fw-bold">Important -</span> Remove all mods and cheats for Legends: Arceus before proceeding. Mods/cheats can alter the RNG of the games and cause RAM reads to fail.
+
+    <p></p>
+    <p>Switch mods/cheats are stored in the <code span class="fw-bold">atmosphere/contents</code> directory on your SD card. This folder is typically empty on a fresh installation of Atmosph&egrave;re.</p>
+
+    <details>
+        <summary><span class="fw-bold">Methods for Disabling Mods/Cheats</span></summary>
+        <p>Any of these methods can work to disable mods/cheats. You should select the best one for your use case.</p>
+
+        <ul>
+            <li>Rename the <code span class="fw-bold">atmosphere/contents</code> folder to something else, such as <code span class="fw-bold">oldcontents</code>. This will allow you to keep everything you previously installed. You can simply rename the folder back when done.</li>
+            <li>Delete the <code span class="fw-bold">atmosphere/contents</code> folder. This may be a good option if you have many files in this directory that you do not recognize and you want to clean out your SD card.</li>
+            <li>Delete specific mods/cheats from the <code span class="fw-bold">atmosphere/contents</code> folder. This requires you to know which title ID corresponds to what.</li>
+            <li>If you wish to keep the <code span class="fw-bold">atmosphere/contents</code> folder intact, you can hold <code span class="fw-bold">L</code> every time you boot the game.</li>
+        </ul>
+    </details>
+</div>
+
 <div class="card border-dark">
     <div class="anchored card-header" style="background-color: #6f3b97;" id="setup-and-install-la-legendary">
         <span class="fw-bold text-light">Required Software</span>
@@ -126,7 +145,7 @@ permalink: /cfw/la/legendary/
             <li>Open Legends: Arceus on your console and enter the overworld, then click <code class="fw-bold">Start All</code>.</li>
             <li>Look inside the <code class="fw-bold">Logs</code> tab, you should now see your trainer information (OT/TID).</li>
         </ul>
-        
+
         <p>If you are running into issues communicating with the console, confirm that sys-botbase has been properly installed by following the installation steps listed above. Refer to the troubleshooting Wiki if you are still running into issues. Do not continue following the guide until the bot is able to interact with your console with no issues.</p>
     </div>
 </div>

--- a/cfw/lgpe/bird-watching/index.html
+++ b/cfw/lgpe/bird-watching/index.html
@@ -19,6 +19,33 @@ permalink: /cfw/lgpe/bird-watching
     <span class="fw-bold">Important -</span> From here it is assumed that you are using a Custom Firmware (CFW) Switch console running Atmosphere. This program is not intended to be used on emulator and cannot be used on retail hardware. You must also progress the game story enough to have access to overworld legendary birds.
 </div>
 
+<hr /><div class="title" style="background-color: #0c5b74;">
+    <h1 class="text-light text-center pt-3 pb-3">Software Installation &amp; Setup</h1>
+</div>
+<small class="text-muted mb-3 mt-0">
+    This section provides setup and installation instructions for PC and Switch software.
+</small>
+<hr />
+
+<div class="alert alert-danger" style="border: 1px solid #a80404; border-radius: 8px; padding: 15px; background-color: #f8d7da; color: #721c24;">
+    <span class="fw-bold">Important -</span> Remove all mods and cheats for LGPE before proceeding. Mods/cheats can alter the RNG of the games and cause RAM reads to fail.
+
+    <p></p>
+    <p>Switch mods/cheats are stored in the <code span class="fw-bold">atmosphere/contents</code> directory on your SD card. This folder is typically empty on a fresh installation of Atmosph&egrave;re.</p>
+
+    <details>
+        <summary><span class="fw-bold">Methods for Disabling Mods/Cheats</span></summary>
+        <p>Any of these methods can work to disable mods/cheats. You should select the best one for your use case.</p>
+
+        <ul>
+            <li>Rename the <code span class="fw-bold">atmosphere/contents</code> folder to something else, such as <code span class="fw-bold">oldcontents</code>. This will allow you to keep everything you previously installed. You can simply rename the folder back when done.</li>
+            <li>Delete the <code span class="fw-bold">atmosphere/contents</code> folder. This may be a good option if you have many files in this directory that you do not recognize and you want to clean out your SD card.</li>
+            <li>Delete specific mods/cheats from the <code span class="fw-bold">atmosphere/contents</code> folder. This requires you to know which title ID corresponds to what.</li>
+            <li>If you wish to keep the <code span class="fw-bold">atmosphere/contents</code> folder intact, you can hold <code span class="fw-bold">L</code> every time you boot the game.</li>
+        </ul>
+    </details>
+</div>
+
 <div class="card border-dark">
     <div class="anchored card-header" style="background-color: #0c5b74;" id="requirements-birdwatch">
         <span class="fw-bold text-light">Getting Started</span>

--- a/cfw/lgpe/item/index.html
+++ b/cfw/lgpe/item/index.html
@@ -19,6 +19,33 @@ permalink: /cfw/lgpe/item
     <span class="fw-bold">Important -</span> From here it is assumed that you are using a Custom Firmware (CFW) Switch console running Atmosphere. This program is not intended to be used on emulator and cannot be used on retail hardware.
 </div>
 
+<hr /><div class="title" style="background-color: #0c5b74;">
+    <h1 class="text-light text-center pt-3 pb-3">Software Installation &amp; Setup</h1>
+</div>
+<small class="text-muted mb-3 mt-0">
+    This section provides setup and installation instructions for PC and Switch software.
+</small>
+<hr />
+
+<div class="alert alert-danger" style="border: 1px solid #a80404; border-radius: 8px; padding: 15px; background-color: #f8d7da; color: #721c24;">
+    <span class="fw-bold">Important -</span> Remove all mods and cheats for LGPE before proceeding. Mods/cheats can alter the RNG of the games and cause RAM reads to fail.
+
+    <p></p>
+    <p>Switch mods/cheats are stored in the <code span class="fw-bold">atmosphere/contents</code> directory on your SD card. This folder is typically empty on a fresh installation of Atmosph&egrave;re.</p>
+
+    <details>
+        <summary><span class="fw-bold">Methods for Disabling Mods/Cheats</span></summary>
+        <p>Any of these methods can work to disable mods/cheats. You should select the best one for your use case.</p>
+
+        <ul>
+            <li>Rename the <code span class="fw-bold">atmosphere/contents</code> folder to something else, such as <code span class="fw-bold">oldcontents</code>. This will allow you to keep everything you previously installed. You can simply rename the folder back when done.</li>
+            <li>Delete the <code span class="fw-bold">atmosphere/contents</code> folder. This may be a good option if you have many files in this directory that you do not recognize and you want to clean out your SD card.</li>
+            <li>Delete specific mods/cheats from the <code span class="fw-bold">atmosphere/contents</code> folder. This requires you to know which title ID corresponds to what.</li>
+            <li>If you wish to keep the <code span class="fw-bold">atmosphere/contents</code> folder intact, you can hold <code span class="fw-bold">L</code> every time you boot the game.</li>
+        </ul>
+    </details>
+</div>
+
 <div class="card border-dark">
     <div class="anchored card-header" style="background-color: #0c5b74;" id="requirements-lgpe-item">
         <span class="fw-bold text-light">Getting Started</span>

--- a/cfw/sv/raidcrawler/index.html
+++ b/cfw/sv/raidcrawler/index.html
@@ -19,6 +19,33 @@ permalink: /cfw/sv/raidcrawler/
     <span class="fw-bold">Important -</span> From here it is assumed that you are using a Custom Firmware (CFW) Switch console running Atmosphere. This program is not intended to be used on emulator and cannot be used on retail hardware. You must also progress the game story enough to have access to Tera Raids.
 </div>
 
+<hr /><div class="title" style="background-color: #0c0038;">
+    <h1 class="text-light text-center pt-3 pb-3">Software Installation &amp; Setup</h1>
+</div>
+<small class="text-muted mb-3 mt-0">
+    This section provides setup and installation instructions for PC and Switch software.
+</small>
+<hr />
+
+<div class="alert alert-danger" style="border: 1px solid #a80404; border-radius: 8px; padding: 15px; background-color: #f8d7da; color: #721c24;">
+    <span class="fw-bold">Important -</span> Remove all mods and cheats for SV before proceeding. Mods/cheats can alter the RNG of the games and cause RAM reads to fail.
+
+    <p></p>
+    <p>Switch mods/cheats are stored in the <code span class="fw-bold">atmosphere/contents</code> directory on your SD card. This folder is typically empty on a fresh installation of Atmosph&egrave;re.</p>
+
+    <details>
+        <summary><span class="fw-bold">Methods for Disabling Mods/Cheats</span></summary>
+        <p>Any of these methods can work to disable mods/cheats. You should select the best one for your use case.</p>
+
+        <ul>
+            <li>Rename the <code span class="fw-bold">atmosphere/contents</code> folder to something else, such as <code span class="fw-bold">oldcontents</code>. This will allow you to keep everything you previously installed. You can simply rename the folder back when done.</li>
+            <li>Delete the <code span class="fw-bold">atmosphere/contents</code> folder. This may be a good option if you have many files in this directory that you do not recognize and you want to clean out your SD card.</li>
+            <li>Delete specific mods/cheats from the <code span class="fw-bold">atmosphere/contents</code> folder. This requires you to know which title ID corresponds to what.</li>
+            <li>If you wish to keep the <code span class="fw-bold">atmosphere/contents</code> folder intact, you can hold <code span class="fw-bold">L</code> every time you boot SV. This option will not work if RaidCrawler is resetting the game for degraded performance.</li>
+        </ul>
+    </details>
+</div>
+
 <div class="card border-dark">
     <div class="anchored card-header" style="background-color: #0c0038;" id="download-and-installation-raidcrawler">
         <span class="fw-bold text-light">Download &amp; Installation</span>
@@ -26,7 +53,7 @@ permalink: /cfw/sv/raidcrawler/
     <div class="card-body card-bg">
         <h6><span class="fw-bold">Required Downloads</span></h6>
         <ul>
-            <li><a href="https://github.com/LegoFigure11/RaidCrawler/releases/" target="_blank">RaidCrawler</a></li>
+            <li><a href="https://github.com/LegoFigure11/RaidCrawler/releases/" target="_blank">RaidCrawler</a></li> (includes sys-botbase)
             <li><a href="https://dotnet.microsoft.com/en-us/download/dotnet/thank-you/runtime-9.0.6-windows-x64-installer" target="_blank" rel="noopener noreferrer">.NET 9.0 Runtime</a></li>
         </ul>
 
@@ -98,9 +125,9 @@ permalink: /cfw/sv/raidcrawler/
         <span class="fw-bold text-light">Filter Condition Information</span>
     </div>
     <div class="card-body card-bg">
-        <p>Clicking the <code span class="fw-bold">Edit Filters</code> button opens the Filter Settings subwindow, here is where you can set the conditions that will tell RaidCrawler to stop scanning for raids once a result has been found.</p> 
+        <p>Clicking the <code span class="fw-bold">Edit Filters</code> button opens the Filter Settings subwindow. Here, you can set the conditions that will tell RaidCrawler to stop scanning for raids once a result has been found.</p>
 
-        <p>You can set filters to search for a single specific target or search for multiple targets at once. Such as filtering for any shiny Pok&eacute;mon OR a 6IV Pok&eacute;mon, or filtering for a shiny Pok&eacute;mon WITH 6IVs. Filters can be enabled or disabled at will by checking/unchecking the boxes on the right-hand side of the subwindow.</p>
+        <p>You can set filters to search for a single specific target or search for multiple targets at once, such as filtering for any shiny Pok&eacute;mon OR a 6IV Pok&eacute;mon, or filtering for a shiny Pok&eacute;mon WITH 6IVs. Filters can be enabled or disabled at will by checking/unchecking the boxes on the right-hand side of the subwindow.</p>
 
         <h6><span class="fw-bold">Search Filter Example</span></h6>
         <ul>

--- a/cfw/swsh/item/index.html
+++ b/cfw/swsh/item/index.html
@@ -100,6 +100,25 @@ permalink: /cfw/swsh/item/
 </small>
 <hr />
 
+<div class="alert alert-danger" style="border: 1px solid #a80404; border-radius: 8px; padding: 15px; background-color: #f8d7da; color: #721c24;">
+    <span class="fw-bold">Important -</span> Remove all mods and cheats for SwSh before proceeding. Mods/cheats can alter the RNG of the games and cause RAM reads to fail.
+
+    <p></p>
+    <p>Switch mods/cheats are stored in the <code span class="fw-bold">atmosphere/contents</code> directory on your SD card. This folder is typically empty on a fresh installation of Atmosph&egrave;re.</p>
+
+    <details>
+        <summary><span class="fw-bold">Methods for Disabling Mods/Cheats</span></summary>
+        <p>Any of these methods can work to disable mods/cheats. You should select the best one for your use case.</p>
+
+        <ul>
+            <li>Rename the <code span class="fw-bold">atmosphere/contents</code> folder to something else, such as <code span class="fw-bold">oldcontents</code>. This will allow you to keep everything you previously installed. You can simply rename the folder back when done.</li>
+            <li>Delete the <code span class="fw-bold">atmosphere/contents</code> folder. This may be a good option if you have many files in this directory that you do not recognize and you want to clean out your SD card.</li>
+            <li>Delete specific mods/cheats from the <code span class="fw-bold">atmosphere/contents</code> folder. This requires you to know which title ID corresponds to what.</li>
+            <li>If you wish to keep the <code span class="fw-bold">atmosphere/contents</code> folder intact, you can hold <code span class="fw-bold">L</code> every time you boot the game.</li>
+        </ul>
+    </details>
+</div>
+
 <div class="card border-dark">
     <div class="anchored card-header" style="background-color: #0c0038;" id="setup-and-install-swsh-overworld-cfw">
         <span class="fw-bold text-light">Required Software</span>
@@ -123,7 +142,7 @@ permalink: /cfw/swsh/item/
 
         <p>Ensure that sys-botbase (bundled with the owoow download) and ldn_mitm have been properly installed before continuing. You should see two separate folders named <code class="fw-bold">430000000000B</code> and <code class="fw-bold">420000000010</code> inside the <code class="fw-bold">atmosphere/contents</code> directory of your SD card if done correctly.</p>
 
-        <p>If ldn_mitm is not available or there is no working release, you will have to connect to Y-Comm or enable LAN mode for Wi-Fi connectivity. You can enable LAN mode by going to the settings in SWSH and pressing <code class="fw-bold">L</code> + <code class="fw-bold">R</code> + <code class="fw-bold">L-Stick</code> (<a class="clickable-image" data-image="https://raw.githubusercontent.com/Billo-PS/billo-guides-images/refs/heads/main/cfw/swsh/overworld/main-page/booting-lan-mode.jpg">Booting LAN</a>, <a class="clickable-image" data-image="https://raw.githubusercontent.com/Billo-PS/billo-guides-images/refs/heads/main/cfw/swsh/overworld/main-page/lan-mode.jpg">LAN enabled</a>). You will not have a <code class="fw-bold">420000000010</code> folder in the <code class="fw-bold">atmosphere/contents</code> directory since the outdated sys-module will crash Atmosph&egrave;re.</p>
+        <p>If ldn_mitm is not available or there is no working release, you will have to connect to Y-Comm or enable LAN mode for Wi-Fi connectivity. You can enable LAN mode by going to the settings in SwSh and pressing <code class="fw-bold">L</code> + <code class="fw-bold">R</code> + <code class="fw-bold">L-Stick</code> (<a class="clickable-image" data-image="https://raw.githubusercontent.com/Billo-PS/billo-guides-images/refs/heads/main/cfw/swsh/overworld/main-page/booting-lan-mode.jpg">Booting LAN</a>, <a class="clickable-image" data-image="https://raw.githubusercontent.com/Billo-PS/billo-guides-images/refs/heads/main/cfw/swsh/overworld/main-page/lan-mode.jpg">LAN enabled</a>). You will not have a <code class="fw-bold">420000000010</code> folder in the <code class="fw-bold">atmosphere/contents</code> directory since the outdated sys-module will crash Atmosph&egrave;re.</p>
 
         <h6><span class="fw-bold">Program Connectivity Instructions (WI-FI ONLY)</span></h6>
         <ol>

--- a/cfw/swsh/overworld/advancing-rng-state/index.html
+++ b/cfw/swsh/overworld/advancing-rng-state/index.html
@@ -1,11 +1,11 @@
 ---
 layout: default
-title: Overworld RNG - Advancing The RNG State
+title: Overworld RNG - Advancing the RNG State
 permalink: /cfw/swsh/overworld/advancing-the-rng-state
 ---
 
 <div class="title" style="background-color: #0c0038;">
-    <h1 class="text-light text-center pt-3 pb-3">Advancing The RNG State</h1>
+    <h1 class="text-light text-center pt-3 pb-3">Advancing the RNG State</h1>
 </div>
 <small class="text-muted mb-3 mt-0">
     Understanding the common methods used to advance the RNG state.
@@ -298,6 +298,8 @@ permalink: /cfw/swsh/overworld/advancing-the-rng-state
     </div>
     <div class="card-body card-bg">
         <p>The <code span class="fw-bold">Skip</code> feature of the RNG tool artificially adjusts the Switch system clock, which advances the RNG state rapidly. This can also be done manually with the PvP date skipping exploit (<a href="https://billo-guides.github.io/retail/swsh/overworld/advancing-the-rng-state#advancements-method-date-skipping">retail guide link</a>). The number of advances consumed per day skipped varies based on the number of Pok&eacute;mon currently stored in boxes (excluding eggs). With optimal box management, it is possible to consume upwards of 16,000 advancements per day skipped.</p>
+
+        <p>Refer to the section on <a href="https://billo-guides.github.io/cfw/swsh/overworld/automation-methods#automated-date-skipping" target="_blank" rel="noopener noreferrer">Date Skipping Automation</a> section of the <code span class="fw-bold">Automation Methods</code> page to learn how to set this up.</p>
 
         <p><code span class="fw-bold">target frame / number of advances per day skipped = number of days to skip</code></p>
 

--- a/cfw/swsh/overworld/automation-methods/index.html
+++ b/cfw/swsh/overworld/automation-methods/index.html
@@ -29,9 +29,10 @@ permalink: /cfw/swsh/overworld/automation-methods
             <li>The <code class="fw-bold">Days+</code> button is used to advance the date FORWARDS, which will advance the RNG state. The number of advances per day is variable.</li>
             <li>The <code class="fw-bold">Days-</code> button is used to advance the date BACKWARDS, which will NOT advance the RNG state. This is useful for setting weather conditions.</li>
             <li>The <code class="fw-bold">NTP</code> button stands for Network Time Protocol. This re-syncs your system time/date back to a sane value. Press this button after completing an RNG.</li>
+            <li>Additional settings to control when to automatically NTP can be found under <code class="fw-bold">Turbo Controls</code>.</li>
         </ul>
 
-        <p>To begin the date skipping process, set your Switch System settings to synchronize your console date/time via the internet. Simply stand in the overworld and type the amount of days you wish to skip into the <code span class="fw-bold">Skip:</code> field (see image) and click the <code span class="fw-bold">Days+</code> button. If this was done correctly you should notice that the RNG state has started to advancing rapidly.</p>
+        <p>To begin the date skipping process, set your Switch System settings to synchronize your console date/time via the internet. Simply stand in the overworld and type the number of days you wish to skip into the <code span class="fw-bold">Skip:</code> field (see image) and click the <code span class="fw-bold">Days+</code> button. If this was done correctly you should notice that the RNG state has started to advancing rapidly.</p>
 
         <p>The automation methods after this use automated button pressing. Your Joy-Cons must be attached to the console. Alternatively, you can disconnect all controllers from the <code class="fw-bold">System Settings > Controllers and Settings</code> menu after entering the party summary screen. You should make sure no extra controllers such as a Pro Controller are connected.</p>
     </div>
@@ -39,7 +40,7 @@ permalink: /cfw/swsh/overworld/automation-methods
 <br>
 
 <div class="alert alert-danger" style="border: 1px solid #b60606; border-radius: 8px; padding: 15px; background-color: #f8d7da; color: #721c24;">
-    <span class="fw-bold">Important -</span> Avoid date skipping over 1000 consecutive days inside any of the Wild Areas as this is likely to cause the game to crash. To avoid this, date skip in increments of 1000 or enter leave the wild area when skipping a large amount of days. It is recommended to relocate to an indoor location or route. It is HIGHLY recommended to stay within sane date boundaries (i.e. do not skip past the year 2060 as this is this is the maximum date you can legally set on your console).
+    <span class="fw-bold">Important -</span> Avoid date skipping over 1000 consecutive days inside any of the Wild Areas as this is likely to cause the game to crash. To avoid this, date skip in increments of 1000 or enter leave the wild area when skipping a large number of days. It is recommended to relocate to an indoor location or route. It is HIGHLY recommended to stay within sane date boundaries (i.e. do not skip past the year 2060 as this is this is the maximum date you can legally set on your console).
 </div>
 
 <div class="alert alert-danger" style="border: 1px solid #b60606; border-radius: 8px; padding: 15px; background-color: #f8d7da; color: #721c24;">

--- a/cfw/swsh/overworld/fishing/index.html
+++ b/cfw/swsh/overworld/fishing/index.html
@@ -40,6 +40,8 @@ permalink: /cfw/swsh/overworld/fishing/
 
         <p>At least 500 KOs on the target species are required to maximize Brilliant Aura bonuses. A more practical alternative is 100 KOs with Shiny Charm boosts, improving shiny rates from 1/1024 to 1/683.08. This provides a significant advantage with much less effort. For more details on Brilliant Aura and Shiny rates, refer to <a href="https://bulbapedia.bulbagarden.net/wiki/Brilliant_Pok%C3%A9mon#Appearance_rate" target="_blank">Bulbapedia</a>.</p>
 
+        <p>Note that even though this value is frequently called the "KO count," the Pok&eacute;dex actually includes all completed battles whether they were captures or true KOs. The number by <code class="fw-bold">Number Battled</code> in the Pok&eacute;dex should be entered in owoow.</p>
+
         <p class="fw-bold" style="color: #c00000;"><small>KO COUNT MUST BE CONFIGURED PROPERLY IN OWOOW TO AVOID POTENTIAL ISSUES.</small></p>
     </div>
 </div>

--- a/cfw/swsh/overworld/main-page/index.html
+++ b/cfw/swsh/overworld/main-page/index.html
@@ -70,6 +70,25 @@ permalink: /cfw/swsh/overworld/main-page
 </small>
 <hr />
 
+<div class="alert alert-danger" style="border: 1px solid #a80404; border-radius: 8px; padding: 15px; background-color: #f8d7da; color: #721c24;">
+    <span class="fw-bold">Important -</span> Remove all mods and cheats for SwSh before proceeding. Mods/cheats can alter the RNG of the games and cause RAM reads to fail.
+
+    <p></p>
+    <p>Switch mods/cheats are stored in the <code span class="fw-bold">atmosphere/contents</code> directory on your SD card. This folder is typically empty on a fresh installation of Atmosph&egrave;re.</p>
+
+    <details>
+        <summary><span class="fw-bold">Methods for Disabling Mods/Cheats</span></summary>
+        <p>Any of these methods can work to disable mods/cheats. You should select the best one for your use case.</p>
+
+        <ul>
+            <li>Rename the <code span class="fw-bold">atmosphere/contents</code> folder to something else, such as <code span class="fw-bold">oldcontents</code>. This will allow you to keep everything you previously installed. You can simply rename the folder back when done.</li>
+            <li>Delete the <code span class="fw-bold">atmosphere/contents</code> folder. This may be a good option if you have many files in this directory that you do not recognize and you want to clean out your SD card.</li>
+            <li>Delete specific mods/cheats from the <code span class="fw-bold">atmosphere/contents</code> folder. This requires you to know which title ID corresponds to what.</li>
+            <li>If you wish to keep the <code span class="fw-bold">atmosphere/contents</code> folder intact, you can hold <code span class="fw-bold">L</code> every time you boot SwSh. This option will not work if you are using automatic seed resetting in owoow.</li>
+        </ul>
+    </details>
+</div>
+
 <div class="card border-dark">
     <div class="anchored card-header" style="background-color: #0c0038;" id="setup-and-install-swsh-overworld-cfw">
         <span class="fw-bold text-light">Required Software</span>
@@ -93,7 +112,7 @@ permalink: /cfw/swsh/overworld/main-page
 
         <p>Ensure that sys-botbase (bundled with the owoow download) and ldn_mitm have been properly installed before continuing. You should see two separate folders named <code class="fw-bold">430000000000B</code> (sys-botbase) and <code class="fw-bold">420000000010</code> (ldn_mitm) in the <code class="fw-bold">atmosphere/contents</code> directory of your SD card.</p>
 
-        <p>If ldn_mitm is not available or there is no working release, you will have to connect to Y-Comm or enable LAN mode for Wi-Fi connectivity. You can enable LAN mode by going to the settings in SWSH and pressing <code class="fw-bold">L</code> + <code class="fw-bold">R</code> + <code class="fw-bold">L-Stick</code> (<a class="clickable-image" data-image="https://raw.githubusercontent.com/Billo-PS/billo-guides-images/refs/heads/main/cfw/swsh/overworld/main-page/booting-lan-mode.jpg">Booting LAN</a>, <a class="clickable-image" data-image="https://raw.githubusercontent.com/Billo-PS/billo-guides-images/refs/heads/main/cfw/swsh/overworld/main-page/lan-mode.jpg">LAN enabled</a>). You will not have a <code class="fw-bold">420000000010</code> folder in the <code class="fw-bold">atmosphere/contents</code> directory since the outdated sys-module will crash Atmosph&egrave;re.</p>
+        <p>If ldn_mitm is not available or there is no working release, you will have to connect to Y-Comm or enable LAN mode for Wi-Fi connectivity. You can enable LAN mode by going to the settings in SwSh and pressing <code class="fw-bold">L</code> + <code class="fw-bold">R</code> + <code class="fw-bold">L-Stick</code> (<a class="clickable-image" data-image="https://raw.githubusercontent.com/Billo-PS/billo-guides-images/refs/heads/main/cfw/swsh/overworld/main-page/booting-lan-mode.jpg">Booting LAN</a>, <a class="clickable-image" data-image="https://raw.githubusercontent.com/Billo-PS/billo-guides-images/refs/heads/main/cfw/swsh/overworld/main-page/lan-mode.jpg">LAN enabled</a>). You will not have a <code class="fw-bold">420000000010</code> folder in the <code class="fw-bold">atmosphere/contents</code> directory since the outdated sys-module will crash Atmosph&egrave;re.</p>
 
         <h6><span class="fw-bold">Program Connectivity Instructions (WI-FI ONLY)</span></h6>
         <ol>

--- a/cfw/swsh/overworld/roaming/index.html
+++ b/cfw/swsh/overworld/roaming/index.html
@@ -65,7 +65,7 @@ permalink: /cfw/swsh/overworld/roaming/
                 <li>You can use any Pok&eacute;mon you want to fill this role as long as it has a "fondly" memory.</li>
                 <li>Remember that after the bird is generated, all of its details are fully decided, so you can freely change your party afterwards using the PC Box Link.</li>
             </ul>
-            <li>Visit the <a class="clickable-image" data-image="https://raw.githubusercontent.com/Billo-PS/billo-guides-images/refs/heads/main/cfw/swsh/overworld/roaming/memory-check-npc.png">Memory Check NPC</a> found in any Pok&eacute;Center and repeatedly rename your remaining Pok&eacute;mon until it has a memory intensity of "fondly remembers".</li>
+            <li>Visit the <a class="clickable-image" data-image="https://raw.githubusercontent.com/Billo-PS/billo-guides-images/refs/heads/main/cfw/swsh/overworld/roaming/memory-check-npc.png">Memory Check NPC</a> found in any Pok&eacute;mon Center and repeatedly rename your remaining Pok&eacute;mon until it has a memory intensity of "fondly remembers".</li>
             <ul>
                 <li>Do not use a Pok&eacute;mon with a map memory! This will cause your RNG manipulation attempt to fail. The map memory text looks similar to "Urshifu checked a destination with Billo using the Town Map in a town in the mountains."</li>
                 <li>The simplest way to achieve a "fondly" intensity memory is by renaming your Pok&eacute;mon multiple times. Confirm the memory intensity by speaking to the NPC.</li>
@@ -155,14 +155,21 @@ permalink: /cfw/swsh/overworld/roaming/
             <li>Confirm that you have a single Pok&eacute;mon in your party. This should be the same Pok&eacute;mon that was given a "fondly" intensity memory earlier.</li>
             <li>Set the current weather condition to anything that is NOT Rain/Thunderstorm both in-game and on owoow. Save the game after doing so.</li>
             <li>Calibrate your current menu close NPC count, then close the <code class="fw-bold">MenuCloseTimeline</code> subwindow. Note down your current menu close NPC count.</li>
-            <li>Set your current menu close NPC count to 0 for now, but ensure that the <code class="fw-bold">Consider Menu Close?</code> checkbox remains checked.</li>
             <li>Refer to the correct table above based on your chosen weather, target bird, and game version/progression (Moltres).</li>
-            <ul>
+            <ol>
                 <li>Set your <code class="fw-bold">Area Load</code> value in the <code class="fw-bold">Advanced Settings</code> on owoow. This will be the same regardless of weather condition.</li>
-                <li>If you are NOT in Rain/Thunderstorm, enter the <code class="fw-bold">Total Fly NPC</code> value into the Fly NPC field in <code class="fw-bold">Advanced Settings</code>.</li>
-                <li>If you are in Rain/Thunderstorm, enter the <code class="fw-bold">NPC 0</code> value into the menu close NPC field, then enter the <code class="fw-bold">NPC 1</code> value into the Fly NPC field in <code class="fw-bold">Advanced Settings</code>.</li>
-                <li>Enter the <code class="fw-bold">Rain Tick</code> value depending on if you are in Rain or Thunderstorm. If this is your first time calibrating, pick the lowest possible value (7 for Rain, 14 for Thunderstorm).</li>
-            </ul>
+                <li>If you are NOT in Rain/Thunderstorm:</li>
+                <ol>
+                    <li>Ensure the menu close NPC count is set to 0.</li>
+                    <li>Enter the <code class="fw-bold">Total Fly NPC</code> value into the <code class="fw-bold">Fly NPCs</code> field under <code class="fw-bold">Advanced Settings</code>.</li>
+                </ol>
+                <li>If you are in Rain/Thunderstorm:</li>
+                <ol>
+                    <li>Enter the <code class="fw-bold">NPC 0</code> value into the menu close NPC field.</li>
+                    <li>Enter the <code class="fw-bold">NPC 1</code> value into the <code class="fw-bold">Fly NPCs</code> field under <code class="fw-bold">Advanced Settings</code>.</li>
+                    <li>Set the <code class="fw-bold">Rain Tick</code> value depending on if you are in Rain or Thunderstorm. If this is your first time calibrating, pick the lowest possible value (7 for Rain, 14 for Thunderstorm).</li>
+                </ol>
+            </ol>
         </ol>
 
         <p>The calibration values (<code class="fw-bold">Consider Menu Close?</code> / <code class="fw-bold">Menu Close NPCs</code> <code class="fw-bold">Area Load</code> / <code class="fw-bold">Fly NPCs</code> / <code class="fw-bold">Rain Ticks</code>) will account for the advances consumed when exiting from the party list -> main <code class="fw-bold">X Menu</code> -> opening map -> flying into the area that contains your bird.</p>
@@ -197,9 +204,10 @@ permalink: /cfw/swsh/overworld/roaming/
                 <li>Consider using wet weather if you wish to maintain an accurate calibration without moving.</li>
             </ul>
             <li>Stop advancing once you are a few thousand advances before your target.</li>
-            <li>Fly back to the designated fly point for your desired bird if you have moved.</li>
+            <li>Fly back to the designated fly point for your desired bird if you moved or date skipped.</li>
             <ul>
-                <li>If you used date skipping to advance earlier, you MUST recalibrate your menu close NPC count and update all of the calibration values accordingly before proceeding.</li>
+                <li>If you used date skipping to advance earlier, you MUST recheck your menu close NPC count and update all of the calibration values from the table accordingly before proceeding.</li>
+                <li>Date skipping or booting into the game on a later date than you saved on can cause the menu NPC count to change, which is why it is important to verify again before performing the RNG manipulation.</li>
             </ul>
             <li>Ensure that the <code class="fw-bold">Consider Menu Close?</code> checkbox is checked in the main window, and confirm that your calibration checkboxes are filled in correctly.</li>
             <li>Use any of the medium-speed advancement methods such as <a class="clickable-image" data-image="https://raw.githubusercontent.com/Billo-PS/billo-guides-images/refs/heads/main/cfw/swsh/overworld/advancing-rng-state/bike-mount.gif">bike hopping</a> and <a class="clickable-image" data-image="https://raw.githubusercontent.com/Billo-PS/billo-guides-images/refs/heads/main/cfw/swsh/overworld/advancing-rng-state/menu-close.gif">menu close</a> to get to about 200-500 advances from your target.</li>

--- a/cfw/swsh/overworld/symbol/index.html
+++ b/cfw/swsh/overworld/symbol/index.html
@@ -40,6 +40,8 @@ permalink: /cfw/swsh/overworld/symbol/
 
         <p>At least 500 KOs on the target species are required to maximize Brilliant Aura bonuses. A more practical alternative is 100 KOs with Shiny Charm boosts, improving shiny rates from 1/1024 to 1/683.08. This provides a significant advantage with much less effort. For more details on Brilliant Aura and Shiny rates, refer to <a href="https://bulbapedia.bulbagarden.net/wiki/Brilliant_Pok%C3%A9mon#Appearance_rate" target="_blank">Bulbapedia</a>.</p>
 
+        <p>Note that even though this value is frequently called the "KO count," the Pok&eacute;dex actually includes all completed battles whether they were captures or true KOs. The number by <code class="fw-bold">Number Battled</code> in the Pok&eacute;dex should be entered in owoow.</p>
+
         <p class="fw-bold" style="color: #c00000;"><small>KO COUNT MUST BE CONFIGURED PROPERLY IN OWOOW TO AVOID POTENTIAL ISSUES.</small></p>
 
     </div>

--- a/cfw/swsh/raid/index.html
+++ b/cfw/swsh/raid/index.html
@@ -30,6 +30,33 @@ permalink: /cfw/swsh/raid
     </svg>
 </a>
 
+<hr /><div class="title" style="background-color: #0c0038;">
+    <h1 class="text-light text-center pt-3 pb-3">Setup and Overview</h1>
+</div>
+<small class="text-muted mb-3 mt-0">
+    This section provides setup and installation instructions and an overview of the RNG tool.
+</small>
+<hr />
+
+<div class="alert alert-danger" style="border: 1px solid #a80404; border-radius: 8px; padding: 15px; background-color: #f8d7da; color: #721c24;">
+    <span class="fw-bold">Important -</span> Remove all mods and cheats for SwSh before proceeding. Mods/cheats can alter the RNG of the games and cause RAM reads to fail.
+
+    <p></p>
+    <p>Switch mods/cheats are stored in the <code span class="fw-bold">atmosphere/contents</code> directory on your SD card. This folder is typically empty on a fresh installation of Atmosph&egrave;re.</p>
+
+    <details>
+        <summary><span class="fw-bold">Methods for Disabling Mods/Cheats</span></summary>
+        <p>Any of these methods can work to disable mods/cheats. You should select the best one for your use case.</p>
+
+        <ul>
+            <li>Rename the <code span class="fw-bold">atmosphere/contents</code> folder to something else, such as <code span class="fw-bold">oldcontents</code>. This will allow you to keep everything you previously installed. You can simply rename the folder back when done.</li>
+            <li>Delete the <code span class="fw-bold">atmosphere/contents</code> folder. This may be a good option if you have many files in this directory that you do not recognize and you want to clean out your SD card.</li>
+            <li>Delete specific mods/cheats from the <code span class="fw-bold">atmosphere/contents</code> folder. This requires you to know which title ID corresponds to what.</li>
+            <li>If you wish to keep the <code span class="fw-bold">atmosphere/contents</code> folder intact, you can hold <code span class="fw-bold">L</code> every time you boot the game.</li>
+        </ul>
+    </details>
+</div>
+
 <div class="card border-dark">
     <div class="anchored card-header" style="background-color: #0c0038;" id="setup-and-install-swsh-max-raid-cfw">
         <span class="fw-bold text-light">Required Software</span>
@@ -74,7 +101,7 @@ permalink: /cfw/swsh/raid
 <br>
 
 <div class="alert alert-danger" style="border: 1px solid #b60606; border-radius: 8px; padding: 15px; background-color: #f8d7da; color: #721c24;">
-    <span class="fw-bold">Important -</span> If ldn_mitm is not available or there is no working release, you will have to connect to Y-Comm or enable LAN mode for Wi-Fi connectivity in LiveHeX. You can enable LAN mode by going to the settings in SWSH and pressing <code class="fw-bold">L</code> + <code class="fw-bold">R</code> + <code class="fw-bold">L-Stick</code> (<a class="clickable-image" data-image="https://raw.githubusercontent.com/Billo-PS/billo-guides-images/refs/heads/main/cfw/swsh/overworld/main-page/booting-lan-mode.jpg">Booting LAN</a>, <a class="clickable-image" data-image="https://raw.githubusercontent.com/Billo-PS/billo-guides-images/refs/heads/main/cfw/swsh/overworld/main-page/lan-mode.jpg">LAN enabled</a>). You will not have a <code class="fw-bold">420000000010</code> folder in the <code class="fw-bold">atmosphere/contents</code> directory since the outdated sys-module will crash Atmosph&egrave;re.
+    <span class="fw-bold">Important -</span> If ldn_mitm is not available or there is no working release, you will have to connect to Y-Comm or enable LAN mode for Wi-Fi connectivity in LiveHeX. You can enable LAN mode by going to the settings in SwSh and pressing <code class="fw-bold">L</code> + <code class="fw-bold">R</code> + <code class="fw-bold">L-Stick</code> (<a class="clickable-image" data-image="https://raw.githubusercontent.com/Billo-PS/billo-guides-images/refs/heads/main/cfw/swsh/overworld/main-page/booting-lan-mode.jpg">Booting LAN</a>, <a class="clickable-image" data-image="https://raw.githubusercontent.com/Billo-PS/billo-guides-images/refs/heads/main/cfw/swsh/overworld/main-page/lan-mode.jpg">LAN enabled</a>). You will not have a <code class="fw-bold">420000000010</code> folder in the <code class="fw-bold">atmosphere/contents</code> directory since the outdated sys-module will crash Atmosph&egrave;re.
 </div>
 
 <hr />

--- a/misc/wonder-card-injection/3ds.html
+++ b/misc/wonder-card-injection/3ds.html
@@ -63,7 +63,7 @@
             <li>Click the <code class="fw-bold">Import</code> button, then select your chosen Wonder Card in the file explorer, you should now see your Wonder Card in the subwindow.</li>
             <li>Right-click an empty Wonder Card slot in the PGT row then click <code class="fw-bold">Set</code> to apply it to your save file. You can now press the <code class="fw-bold">Save</code> button to close the subwindow.</li>
             <li>Export your save file (<code class="fw-bold">File -> Export Sav</code>) and overwrite your existing save file, then load it back onto your cartridge/emulator.</li>
-            <li>Visit the delivery man in-game, he can be found standing next to the desk/PC inside any Pok&eacute;Center.</li>
+            <li>Visit the delivery man in-game. He can be found standing next to the desk/PC inside any Pok&eacute;mon Center.</li>
         </ol>
 
     </div>

--- a/misc/wonder-card-injection/ds.html
+++ b/misc/wonder-card-injection/ds.html
@@ -61,7 +61,7 @@
             <li>Click the <code class="fw-bold">Import</code> button, then select your chosen Wonder Card in the file explorer, you should now see your Wonder Card in the subwindow.</li>
             <li>Right-click an empty Wonder Card slot in the PGT row then click <code class="fw-bold">Set</code> to apply it to your save file. You can now press the <code class="fw-bold">Save</code> button to close the subwindow.</li>
             <li>Export your save file (<code class="fw-bold">File -> Export Sav</code>) and overwrite your existing save file, then load it back onto your cartridge/emulator.</li>
-            <li>Visit the delivery man in-game, in Gen 4 titles he can be found inside the Pok&eacute;Mart, in Gen 5 titles he can be found inside the Pok&eacute;Center.</li>
+            <li>Visit the delivery man in-game. In Gen 4 titles he can be found inside the Pok&eacute; Mart, and in Gen 5 titles he can be found inside the Pok&eacute;mon Center.</li>
         </ol>
 
     </div>

--- a/misc/wonder-card-injection/gba.html
+++ b/misc/wonder-card-injection/gba.html
@@ -60,7 +60,7 @@
     <div class="card-body card-bg">
         <p>In this example we will be injecting the Old Sea Map (Mew) using PKHeX, this event was only distributed on Japanese copies of Pok&eacute;mon Emerald, so we will be using a Japanese Emerald save file to keep things legal. It is advisable to do your own research to ensure that you are injecting your desired event into a save file of the correct language.</p>
 
-        <p>Since we are using a completely fresh save file with low story progress we will need to grant access to the Mystery Gift feature before doing anything else. You do not need to follow this section if you have already gained access to Mystery Gifts on your save file using the <a href="https://projectpokemon.org/home/forums/topic/35903-gen-3-mystery-eventgift-research/" target="_blank" rel="noopener">Pok&eacute;Mart questionnaire</a>.</p>
+        <p>Since we are using a completely fresh save file with low story progress we will need to grant access to the Mystery Gift feature before doing anything else. You do not need to follow this section if you have already gained access to Mystery Gifts on your save file using the <a href="https://projectpokemon.org/home/forums/topic/35903-gen-3-mystery-eventgift-research/" target="_blank" rel="noopener">Pok&eacute; Mart questionnaire</a>.</p>
         <hr />
 
         <h6 class="fw-bold">Mystery Gift Unlock (Using PKHeX)</h6>
@@ -119,7 +119,7 @@
         <span class="fw-bold text-light">In-game Redemption</span>
     </div>
     <div class="card-body card-bg">
-        <p>After injecting your gift, load your save file back onto your cartridge/emulator and head upstairs in any Pok&eacute;Center to redeem your gift. If you were already saved on the upper floor you may need to exit and re-enter for the delivery man to be visible. If done correctly the delivery man should be standing next to the usual NPC on the top left.</p>
+        <p>After injecting your gift, load your save file back onto your cartridge/emulator and head upstairs in any Pok&eacute;mon Center to redeem your gift. If you were already saved on the upper floor you may need to exit and re-enter for the delivery man to be visible. If done correctly the delivery man should be standing next to the usual NPC on the top left.</p>
 
         <p>Once you have recieved the gift you can head over to the docks in Slateport or Lilycove and the sailor will grant access to the map that corrisponds to your event ticket.</p>
     </div>

--- a/retail/lgpe/item/index.html
+++ b/retail/lgpe/item/index.html
@@ -187,7 +187,7 @@ permalink: /retail/lgpe/item
 <p>A target has been found, a Master Ball in x advances, you can now begin advancing the RNG state.</p>
 
 <hr /><div class="title" style="background-color: #0c5b74;">
-  <h1 class="text-light text-center pt-3 pb-3">Advancing The RNG State</h1>
+  <h1 class="text-light text-center pt-3 pb-3">Advancing the RNG State</h1>
 </div><hr />
 
 <p>The following actions are considered to be the best methods to advance the RNG state for both consistency and speed:</p>

--- a/retail/swsh/overworld/advancing-rng-state/index.html
+++ b/retail/swsh/overworld/advancing-rng-state/index.html
@@ -1,11 +1,11 @@
 ---
 layout: default
-title: Overworld RNG - Advancing The RNG State
+title: Overworld RNG - Advancing the RNG State
 permalink: /retail/swsh/overworld/advancing-the-rng-state
 ---
 
 <div class="title" style="background-color: #0c0038;">
-    <h1 class="text-light text-center pt-3 pb-3">Advancing The RNG State</h1>
+    <h1 class="text-light text-center pt-3 pb-3">Advancing the RNG State</h1>
 </div>
 <small class="text-muted mb-3 mt-0">
     Understanding the common methods used to advance the RNG state.

--- a/retail/swsh/overworld/fishing/index.html
+++ b/retail/swsh/overworld/fishing/index.html
@@ -40,6 +40,8 @@ permalink: /retail/swsh/overworld/fishing/
 
         <p>At least 500 KOs on the target species are required to maximize Brilliant Aura bonuses. A more practical alternative is 100 KOs with Shiny Charm boosts, improving shiny rates from 1/1024 to 1/683.08. This provides a significant advantage with much less effort. For more details on Brilliant Aura and Shiny rates, refer to <a href="https://bulbapedia.bulbagarden.net/wiki/Brilliant_Pok%C3%A9mon#Appearance_rate" target="_blank">Bulbapedia</a>.</p>
 
+        <p>Note that even though this value is frequently called the "KO count," the Pok&eacute;dex actually includes all completed battles whether they were captures or true KOs. The number by <code class="fw-bold">Number Battled</code> in the Pok&eacute;dex should be entered in owoow.</p>
+
         <p class="fw-bold" style="color: #c00000;"><small>KO COUNT MUST BE CONFIGURED PROPERLY IN OWOOW TO AVOID POTENTIAL ISSUES.</small></p>
     </div>
 </div>

--- a/retail/swsh/overworld/roaming/index.html
+++ b/retail/swsh/overworld/roaming/index.html
@@ -65,7 +65,7 @@ permalink: /retail/swsh/overworld/roaming/
                 <li>You can use any Pok&eacute;mon you want to fill this role as long as it has a "fondly" memory.</li>
                 <li>Remember that after the bird is generated, all of its details are fully decided, so you can freely change your party afterwards using the PC Box Link.</li>
             </ul>
-            <li>Visit the <a class="clickable-image" data-image="https://raw.githubusercontent.com/Billo-PS/billo-guides-images/refs/heads/main/cfw/swsh/overworld/roaming/memory-check-npc.png">Memory Check NPC</a> found in any Pok&eacute;Center and repeatedly rename your remaining Pok&eacute;mon until it has a memory intensity of "fondly remembers".</li>
+            <li>Visit the <a class="clickable-image" data-image="https://raw.githubusercontent.com/Billo-PS/billo-guides-images/refs/heads/main/cfw/swsh/overworld/roaming/memory-check-npc.png">Memory Check NPC</a> found in any Pok&eacute;mon Center and repeatedly rename your remaining Pok&eacute;mon until it has a memory intensity of "fondly remembers".</li>
             <ul>
                 <li>Do not use a Pok&eacute;mon with a map memory! This will cause your RNG manipulation attempt to fail. The map memory text looks similar to "Urshifu checked a destination with Billo using the Town Map in a town in the mountains."</li>
                 <li>The simplest way to achieve a "fondly" intensity memory is by renaming your Pok&eacute;mon multiple times. Confirm the memory intensity by speaking to the NPC.</li>
@@ -154,14 +154,21 @@ permalink: /retail/swsh/overworld/roaming/
             <li>Confirm that you have a single Pok&eacute;mon in your party. This should be the same Pok&eacute;mon that was given a "fondly" intensity memory earlier.</li>
             <li>Set the current weather condition to anything that is NOT Rain/Thunderstorm both in-game and on owoow. Save the game after doing so.</li>
             <li>Calibrate your current menu close NPC count, then close the <code class="fw-bold">MenuCloseTimeline</code> subwindow. Note down your current menu close NPC count.</li>
-            <li>Set your current menu close NPC count to 0 for now, but ensure that the <code class="fw-bold">Consider Menu Close?</code> checkbox remains checked.</li>
             <li>Refer to the correct table above based on your chosen weather, target bird, and game version/progression (Moltres).</li>
-            <ul>
+            <ol>
                 <li>Set your <code class="fw-bold">Area Load</code> value in the <code class="fw-bold">Advanced Settings</code> on owoow. This will be the same regardless of weather condition.</li>
-                <li>If you are NOT in Rain/Thunderstorm, enter the <code class="fw-bold">Total Fly NPC</code> value into the Fly NPC field in <code class="fw-bold">Advanced Settings</code>.</li>
-                <li>If you are in Rain/Thunderstorm, enter the <code class="fw-bold">NPC 0</code> value into the menu close NPC field, then enter the <code class="fw-bold">NPC 1</code> value into the Fly NPC field in <code class="fw-bold">Advanced Settings</code>.</li>
-                <li>Enter the <code class="fw-bold">Rain Tick</code> value depending on if you are in Rain or Thunderstorm. If this is your first time calibrating, pick the lowest possible value (7 for Rain, 14 for Thunderstorm).</li>
-            </ul>
+                <li>If you are NOT in Rain/Thunderstorm:</li>
+                <ol>
+                    <li>Ensure the menu close NPC count is set to 0.</li>
+                    <li>Enter the <code class="fw-bold">Total Fly NPC</code> value into the <code class="fw-bold">Fly NPCs</code> field under <code class="fw-bold">Advanced Settings</code>.</li>
+                </ol>
+                <li>If you are in Rain/Thunderstorm:</li>
+                <ol>
+                    <li>Enter the <code class="fw-bold">NPC 0</code> value into the menu close NPC field.</li>
+                    <li>Enter the <code class="fw-bold">NPC 1</code> value into the <code class="fw-bold">Fly NPCs</code> field under <code class="fw-bold">Advanced Settings</code>.</li>
+                    <li>Set the <code class="fw-bold">Rain Tick</code> value depending on if you are in Rain or Thunderstorm. If this is your first time calibrating, pick the lowest possible value (7 for Rain, 14 for Thunderstorm).</li>
+                </ol>
+            </ol>
         </ol>
 
         <p>The calibration values (<code class="fw-bold">Consider Menu Close?</code> / <code class="fw-bold">Menu Close NPCs</code> <code class="fw-bold">Area Load</code> / <code class="fw-bold">Fly NPCs</code> / <code class="fw-bold">Rain Ticks</code>) will account for the advances consumed when exiting from the party list -> main <code class="fw-bold">X Menu</code> -> opening map -> flying into the area that contains your bird.</p>
@@ -195,9 +202,10 @@ permalink: /retail/swsh/overworld/roaming/
                 <li>Consider using wet weather if you wish to maintain an accurate calibration without moving.</li>
             </ul>
             <li>Reidentify your current seed periodically to avoid overshooting the target. Stop advancing once you are a few thousand advances before your target.</li>
-            <li>Fly back to the designated fly point for your desired bird if you have moved.</li>
+            <li>Fly back to the designated fly point for your desired bird if you moved or date skipped.</li>
             <ul>
-                <li>If you used date skipping to advance earlier, you MUST recalibrate your menu close NPC count and update all of the calibration values accordingly before proceeding.</li>
+                <li>If you used date skipping to advance earlier, you MUST recheck your menu close NPC count and update all of the calibration values from the table accordingly before proceeding.</li>
+                <li>Date skipping or booting into the game on a later date than you saved on can cause the menu NPC count to change, which is why it is important to verify again before performing the RNG manipulation.</li>
             </ul>
             <li>Ensure that the <code class="fw-bold">Consider Menu Close?</code> checkbox is checked in the main window, and confirm that your calibration checkboxes are filled in correctly.</li>
             <li>Use any of the medium-speed advancement methods such as <a class="clickable-image" data-image="https://raw.githubusercontent.com/Billo-PS/billo-guides-images/refs/heads/main/cfw/swsh/overworld/advancing-rng-state/bike-mount.gif">bike hopping</a> and <a class="clickable-image" data-image="https://raw.githubusercontent.com/Billo-PS/billo-guides-images/refs/heads/main/cfw/swsh/overworld/advancing-rng-state/menu-close.gif">menu close</a> to get to about 200-500 advances from your target.</li>

--- a/retail/swsh/overworld/symbol/index.html
+++ b/retail/swsh/overworld/symbol/index.html
@@ -40,6 +40,8 @@ permalink: /retail/swsh/overworld/symbol/
 
         <p>At least 500 KOs on the target species are required to maximize Brilliant Aura bonuses. A more practical alternative is 100 KOs with Shiny Charm boosts, improving shiny rates from 1/1024 to 1/683.08. This provides a significant advantage with much less effort. For more details on Brilliant Aura and Shiny rates, refer to <a href="https://bulbapedia.bulbagarden.net/wiki/Brilliant_Pok%C3%A9mon#Appearance_rate" target="_blank">Bulbapedia</a>.</p>
 
+        <p>Note that even though this value is frequently called the "KO count," the Pok&eacute;dex actually includes all completed battles whether they were captures or true KOs. The number by <code class="fw-bold">Number Battled</code> in the Pok&eacute;dex should be entered in owoow.</p>
+
         <p class="fw-bold" style="color: #c00000;"><small>KO COUNT MUST BE CONFIGURED PROPERLY IN OWOOW TO AVOID POTENTIAL ISSUES.</small></p>
 
     </div>


### PR DESCRIPTION
Foolproofing the SWSH guide based on issues users have had:
- Added an warning and explanation about removing mods/cheats for all CFW guides. (CFW)
- Explained that "KO count" is actually the "Number Battled" in the dex, which includes captures and defeated. (CFW/Retail)
- Linked the setup instructions for owoow date skipping on the "Advancing the RNG State" page. (CFW)
- Reorganized the Roaming steps to reduce confusion on how to fill in the boxes from tables. (CFW/Retail)
- Added in Roaming RNG steps that you must fly back to the map and check menu NPCs again after date skipping. (CFW/Retail)

General improvements to enhance the user experience:
- Added title cards on BDSP, SV, and LGPE before software installation. (CFW)
- Standardized "PokéCenter" -> "Pokémon Center" and "PokéMart" -> "Poké Mart".
- Titlecased "Advancing the RNG State" in title cards.
- Added a bullet in "Automation Methods" to direct users to additional NTP settings. (CFW)
- Fixed an incorrect link for LINQPad in the BDSP guide (CFW)
- Corrected grammar.